### PR TITLE
Bring on the Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: pytest
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build-and-test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    env:
+      # Configure a constant location for the uv cache
+        UV_CACHE_DIR: /tmp/.uv-cache
+        UV_VERSION: 0.5.20
+        FORCE_COLOR: 1
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Load cached venv
+      id: cached-uv-dependencies
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.uv-cache
+        key: uv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/uv.lock') }}
+    - name: Install dependencies
+      run: |
+        pip install uv==$UV_VERSION
+        uv venv
+        source .venv/bin/activate
+        uv sync --frozen
+    - name: Test with pytest
+      run: |
+        mkdir ~/.aws && touch ~/.aws/credentials && echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
+        source .venv/bin/activate
+        pytest -v
+    - name: Minimize uv cache
+      run: uv cache prune --ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "mypy[faster-cache]>=1.14.1",
     "pytest>=8.3.4",
     "pytest-clarity>=1.0.1",
+    "pytest-socket>=0.7.0",
     "pytest-sugar>=1.0.0",
     "ruff>=0.8.6",
 ]
@@ -40,7 +41,14 @@ dev = [
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
+    "--disable-socket",
+    "--allow-unix-socket"
 ]
+filterwarnings = [
+    "error",
+    "ignore::DeprecationWarning:botocore.auth:424", # handles: 'DeprecationWarning: datetime.datetime.utcnow()'
+]
+
 
 [tool.mypy]
 plugins = [

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 from rich.table import Table
 
+from borgboi import dynamodb
 from borgboi.backups import BorgRepo
-from borgboi.dynamodb import add_repo_to_table, get_all_repos, get_repo_by_name, get_repo_by_path, update_repo
 from borgboi.rich_utils import console
 
 
@@ -26,21 +26,21 @@ def create_borg_repo(path: str, backup_path: str, passphrase_env_var_name: str, 
         hostname=socket.gethostname(),
     )
     new_repo.init_repository()
-    add_repo_to_table(new_repo)
+    dynamodb.add_repo_to_table(new_repo)
     return new_repo
 
 
 def lookup_repo(repo_path: str | None, repo_name: str | None) -> BorgRepo:
     if repo_path is not None:
-        return get_repo_by_path(repo_path)
+        return dynamodb.get_repo_by_path(repo_path)
     elif repo_name is not None:
-        return get_repo_by_name(repo_name)
+        return dynamodb.get_repo_by_name(repo_name)
     else:
         raise ValueError("Either repo_name or repo_path must be provided")
 
 
 def list_repos() -> None:
-    repos = get_all_repos()
+    repos = dynamodb.get_all_repos()
     table = Table(title="BorgBoi Repositories", show_lines=True)
     table.add_column("Name")
     table.add_column("Local Path 📁")
@@ -72,4 +72,4 @@ def perform_daily_backup(repo_path: str) -> None:
     repo.prune()
     repo.compact()
     repo.sync_with_s3()
-    update_repo(repo)
+    dynamodb.update_repo(repo)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def mocked_aws(aws_credentials: None) -> Generator[None, Any, None]:
 
 @pytest.fixture
 def create_dynamodb_table(dynamodb: DynamoDBClient) -> None:
+    # TODO: Add GSI to table
     dynamodb.create_table(
         TableName=DYNAMO_TABLE_NAME,
         KeySchema=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any
 
 import boto3
@@ -14,6 +15,7 @@ DYNAMO_TABLE_NAME = "borg-repos-test"
 @pytest.fixture(autouse=True)
 def _common_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BORG_PASSPHRASE", "test")
+    monkeypatch.setenv("BORG_NEW_PASSPHRASE", "test")
     monkeypatch.setenv("BORG_S3_BUCKET", "test")
     monkeypatch.setenv("BORG_DYNAMODB_TABLE", DYNAMO_TABLE_NAME)
 
@@ -70,3 +72,13 @@ def create_dynamodb_table(dynamodb: DynamoDBClient) -> None:
     )
     waiter = dynamodb.get_waiter("table_exists")
     waiter.wait(TableName=DYNAMO_TABLE_NAME, WaiterConfig={"Delay": 2, "MaxAttempts": 10})
+
+
+@pytest.fixture
+def repo_storage_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp("borgboi-test-repo")
+
+
+@pytest.fixture
+def backup_target_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp("borgboi-test-backup-target")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,6 @@ def mocked_aws(aws_credentials: None) -> Generator[None, Any, None]:
 
 @pytest.fixture
 def create_dynamodb_table(dynamodb: DynamoDBClient) -> None:
-    # TODO: Add GSI to table
     dynamodb.create_table(
         TableName=DYNAMO_TABLE_NAME,
         KeySchema=[
@@ -68,8 +67,23 @@ def create_dynamodb_table(dynamodb: DynamoDBClient) -> None:
         ],
         AttributeDefinitions=[
             {"AttributeName": "repo_path", "AttributeType": "S"},
+            {"AttributeName": "name", "AttributeType": "S"},
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "name_gsi",
+                "KeySchema": [
+                    {"AttributeName": "name", "KeyType": "HASH"},
+                ],
+                "Projection": {
+                    "ProjectionType": "ALL",
+                },
+                "ProvisionedThroughput": {"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
+                "OnDemandThroughput": {"MaxReadRequestUnits": 123, "MaxWriteRequestUnits": 123},
+                "WarmThroughput": {"ReadUnitsPerSecond": 123, "WriteUnitsPerSecond": 123},
+            },
+        ],
     )
     waiter = dynamodb.get_waiter("table_exists")
     waiter.wait(TableName=DYNAMO_TABLE_NAME, WaiterConfig={"Delay": 2, "MaxAttempts": 10})

--- a/tests/dynamodb_test.py
+++ b/tests/dynamodb_test.py
@@ -9,16 +9,6 @@ from .conftest import DYNAMO_TABLE_NAME
 
 
 @pytest.fixture
-def repo_storage_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    return tmp_path_factory.mktemp("borgboi-test-repo")
-
-
-@pytest.fixture
-def backup_target_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    return tmp_path_factory.mktemp("borgboi-test-backup-target")
-
-
-@pytest.fixture
 def borgboi_repo(repo_storage_dir: Path, backup_target_dir: Path) -> BorgRepo:
     return BorgRepo(path=repo_storage_dir, backup_target=backup_target_dir, name="test-repo", hostname="test-host")
 

--- a/tests/dynamodb_test.py
+++ b/tests/dynamodb_test.py
@@ -23,3 +23,29 @@ def test_add_repo_to_table(dynamodb: DynamoDBClient, borgboi_repo: BorgRepo) -> 
     assert "Item" in response
     assert response["Item"]["repo_path"]["S"] == borgboi_repo.path.as_posix()  # pyright: ignore[reportTypedDictNotRequiredAccess]
     assert response["Item"]["passphrase_env_var_name"]["S"] == borgboi_repo.passphrase_env_var_name  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+
+@pytest.mark.usefixtures("create_dynamodb_table")
+def test_update_repo(dynamodb: DynamoDBClient, borgboi_repo: BorgRepo) -> None:
+    from borgboi.dynamodb import add_repo_to_table, get_repo_by_path, update_repo
+
+    new_name = "updated-test-repo-name"
+    new_hostname = "updated-test-hostname"
+
+    # Populate test table with initial repo
+    add_repo_to_table(borgboi_repo)
+    response = dynamodb.get_item(TableName=DYNAMO_TABLE_NAME, Key={"repo_path": {"S": borgboi_repo.path.as_posix()}})
+    assert "Item" in response
+    assert response["Item"]["repo_path"]["S"] == borgboi_repo.path.as_posix()  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert response["Item"]["passphrase_env_var_name"]["S"] == borgboi_repo.passphrase_env_var_name  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+    # Update repo fields and call update_repo(...)
+    borgboi_repo.name = new_name
+    borgboi_repo.hostname = new_hostname
+    update_repo(borgboi_repo)
+
+    # Verify that the repo was updated in the table
+    repo_from_table = get_repo_by_path(borgboi_repo.path.as_posix())
+    assert repo_from_table.name == new_name
+    assert repo_from_table.hostname == new_hostname
+    assert repo_from_table.model_dump() == borgboi_repo.model_dump()

--- a/tests/orchestrator_test.py
+++ b/tests/orchestrator_test.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.usefixtures("create_dynamodb_table")
+def test_create_borg_repo(repo_storage_dir: Path, backup_target_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from borgboi.orchestrator import create_borg_repo
+
+    def mock_init_repository(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    monkeypatch.setattr("borgboi.backups.BorgRepo.init_repository", mock_init_repository)
+    new_repo = create_borg_repo(
+        repo_storage_dir.as_posix(), backup_target_dir.as_posix(), "BORG_NEW_PASSPHRASE", "test-repo"
+    )
+    assert new_repo.path == repo_storage_dir
+    assert new_repo.backup_target == backup_target_dir
+    assert new_repo.name == "test-repo"

--- a/tests/orchestrator_test.py
+++ b/tests/orchestrator_test.py
@@ -18,3 +18,28 @@ def test_create_borg_repo(repo_storage_dir: Path, backup_target_dir: Path, monke
     assert new_repo.path == repo_storage_dir
     assert new_repo.backup_target == backup_target_dir
     assert new_repo.name == "test-repo"
+
+
+@pytest.mark.usefixtures("create_dynamodb_table")
+@pytest.mark.parametrize(("repo_path", "repo_name"), [(None, "test-repo"), ("/path/to/repo", None)])
+def test_lookup_repo(repo_path: str | None, repo_name: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
+    from borgboi.orchestrator import lookup_repo
+
+    path_func_called = False
+    name_func_called = False
+
+    def mock_get_repo_by_path(*args: Any, **kwargs: Any) -> None:
+        path_func_called = True
+
+    def mock_get_repo_by_name(*args: Any, **kwargs: Any) -> None:
+        name_func_called = True
+
+    monkeypatch.setattr("borgboi.dynamodb.get_repo_by_path", mock_get_repo_by_path)
+    monkeypatch.setattr("borgboi.dynamodb.get_repo_by_name", mock_get_repo_by_path)
+    lookup_repo(repo_path, repo_name)
+    if repo_path:
+        assert path_func_called is True
+    elif repo_name:
+        assert name_func_called is True
+    else:
+        raise AssertionError("Either get_repo_by_path or get_repo_by_name should have been called")

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ dev = [
     { name = "mypy", extra = ["faster-cache"] },
     { name = "pytest" },
     { name = "pytest-clarity" },
+    { name = "pytest-socket" },
     { name = "pytest-sugar" },
     { name = "ruff" },
 ]
@@ -47,6 +48,7 @@ dev = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.14.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-clarity", specifier = ">=1.0.1" },
+    { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.8.6" },
 ]
@@ -650,6 +652,18 @@ dependencies = [
     { name = "rich" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/5c/cafa97944de55738a6a2c5a7cee00d073cb80495032d2b112c4546525eca/pytest-clarity-1.0.1.tar.gz", hash = "sha256:505fe345fad4fe11c6a4187fe683f2c7c52c077caa1e135f3e483fe112db7772", size = 4891 }
+
+[[package]]
+name = "pytest-socket"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/ff/90c7e1e746baf3d62ce864c479fd53410b534818b9437413903596f81580/pytest_socket-0.7.0.tar.gz", hash = "sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3", size = 12389 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/58/5d14cb5cb59409e491ebe816c47bf81423cd03098ea92281336320ae5681/pytest_socket-0.7.0-py3-none-any.whl", hash = "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45", size = 6754 },
+]
 
 [[package]]
 name = "pytest-sugar"


### PR DESCRIPTION
Started to add some additional tests since some more functionality has been merged into `main` recently.

### 🤖 Summary

This pull request introduces a new GitHub Actions workflow for running tests and linting, updates dependencies and configurations in `pyproject.toml`, and refactors the `orchestrator.py` module to improve code clarity and maintainability. Additionally, new tests and fixtures are added to enhance test coverage.

### GitHub Actions Workflow:
* Added a new workflow in `.github/workflows/test.yml` to install Python dependencies, run tests, and lint with various Python versions.

### Dependency and Configuration Updates:
* Updated `pyproject.toml` to include `pytest-socket` and additional `pytest` options, and added a filter for deprecation warnings.

### Code Refactoring:
* Refactored `orchestrator.py` to import `dynamodb` module directly and updated function calls to use `dynamodb` methods. [[1]](diffhunk://#diff-84a5b203686439695ea6770c3f126fc014b880bf3c70eae5acef4c1a0550df36R7-L8) [[2]](diffhunk://#diff-84a5b203686439695ea6770c3f126fc014b880bf3c70eae5acef4c1a0550df36L29-R43) [[3]](diffhunk://#diff-84a5b203686439695ea6770c3f126fc014b880bf3c70eae5acef4c1a0550df36L75-R75)

### Test Enhancements:
* Added new fixtures and tests in `conftest.py` and `dynamodb_test.py` to support the new workflow and ensure comprehensive test coverage. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R3) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R18) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R70-R99) [[4]](diffhunk://#diff-be302d6ba1438a1085208d20ddec21c32a6cae0ff4a922c8d644412f6b531e53L11-L20) [[5]](diffhunk://#diff-be302d6ba1438a1085208d20ddec21c32a6cae0ff4a922c8d644412f6b531e53R26-R51)
* Added new tests in `orchestrator_test.py` for creating and looking up Borg repositories.