### PR TITLE
refactor: renamed dynamo table item field from `name` to `common_name`

### DIFF
--- a/src/borgboi/dynamodb.py
+++ b/src/borgboi/dynamodb.py
@@ -13,7 +13,7 @@ class BorgRepoTableItem(BaseModel):
     repo_path: str
     backup_target_path: str
     passphrase_env_var_name: str
-    name: str
+    common_name: str
     hostname: str
     last_backup: str | None = None
     last_s3_sync: str | None = None
@@ -33,7 +33,7 @@ def _convert_repo_to_table_item(repo: BorgRepo) -> BorgRepoTableItem:
         repo_path=repo.path.as_posix(),
         backup_target_path=repo.backup_target.as_posix(),
         passphrase_env_var_name=repo.passphrase_env_var_name,
-        name=repo.name,
+        common_name=repo.name,
         hostname=repo.hostname,
         last_backup=repo.last_backup.isoformat() if repo.last_backup else None,
         last_s3_sync=repo.last_s3_sync.isoformat() if repo.last_s3_sync else None,
@@ -61,7 +61,7 @@ def _convert_table_item_to_repo(repo: BorgRepoTableItem) -> BorgRepo:
         path=Path(repo.repo_path),
         backup_target=Path(repo.backup_target_path),
         passphrase_env_var_name=repo.passphrase_env_var_name,
-        name=repo.name,
+        name=repo.common_name,
         hostname=repo.hostname,
         last_backup=last_backup,
         last_s3_sync=last_s3_sync,

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -14,13 +14,13 @@ resource "aws_dynamodb_table" "borg-repo-table" {
   }
 
   attribute {
-    name = "name"
+    name = "common_name"
     type = "S"
   }
 
   global_secondary_index {
     name            = "name_gsi"
-    hash_key        = "name"
+    hash_key        = "common_name"
     write_capacity  = 5
     read_capacity   = 5
     projection_type = "ALL"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,14 +67,14 @@ def create_dynamodb_table(dynamodb: DynamoDBClient) -> None:
         ],
         AttributeDefinitions=[
             {"AttributeName": "repo_path", "AttributeType": "S"},
-            {"AttributeName": "name", "AttributeType": "S"},
+            {"AttributeName": "common_name", "AttributeType": "S"},
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
         GlobalSecondaryIndexes=[
             {
                 "IndexName": "name_gsi",
                 "KeySchema": [
-                    {"AttributeName": "name", "KeyType": "HASH"},
+                    {"AttributeName": "common_name", "KeyType": "HASH"},
                 ],
                 "Projection": {
                     "ProjectionType": "ALL",


### PR DESCRIPTION
This is being renamed due to 'name' being a reserved field. The follow error was being raised previously: 'ClientError: An error occurred (ValidationException) when calling the Query operation: Invalid KeyConditionExpression: Attribute name
is a reserved keyword; reserved keyword: name'.