### PR TITLE
Support Storing Additional Repo Info Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,9 @@ borgboi daily-backup <path-to-repo>
 - [x] Wrap common borg operations for creating archive, pruning, and compacting
 - [x] Display borg logs to user through terminal as borg is running
 - [x] Sync local borg repo/its archives with a S3 bucket
-- [ ] Add command to print out information on the borg repo
+- [x] Add command to print out information on the borg repo
+- [ ] Document additional commands
+- [ ] Add command to delete borg repo
+- [ ] Add command to download remote borg repo from S3
+- [ ] Add command to restore from borg repo
+- [ ] Additional tests

--- a/src/borgboi/backups.py
+++ b/src/borgboi/backups.py
@@ -169,12 +169,7 @@ class BorgRepo(BaseModel):
 
         https://borgbackup.readthedocs.io/en/stable/usage/info.html
         """
-        cmd_parts = [
-            "borg",
-            "info",
-            # "--json",
-            self.path.as_posix(),
-        ]
+        cmd_parts = ["borg", "info", self.path.as_posix()]
 
         rich_utils.run_and_log_sp_popen(
             cmd_parts=cmd_parts,
@@ -184,6 +179,8 @@ class BorgRepo(BaseModel):
             spinner="triangle",
             use_stderr=False,
         )
+        cmd_parts = ["borg", "info", "--json", self.path.as_posix()]
+        rich_utils.run_and_output_repo_info(cmd_parts)
 
     def export_repo_key(self) -> None:
         """

--- a/src/borgboi/dynamodb.py
+++ b/src/borgboi/dynamodb.py
@@ -17,6 +17,9 @@ class BorgRepoTableItem(BaseModel):
     hostname: str
     last_backup: str | None = None
     last_s3_sync: str | None = None
+    total_size_gb: str = "0.0"
+    total_csize_gb: str = "0.0"
+    unique_csize_gb: str = "0.0"
 
 
 def _convert_repo_to_table_item(repo: BorgRepo) -> BorgRepoTableItem:
@@ -29,6 +32,19 @@ def _convert_repo_to_table_item(repo: BorgRepo) -> BorgRepoTableItem:
     Returns:
         BorgRepoTableItem: Borg repository converted to a DynamoDB table item
     """
+    if repo.metadata is None:
+        size_metadata = {
+            "total_size_gb": "0.0",
+            "total_csize_gb": "0.0",
+            "unique_csize_gb": "0.0",
+        }
+    else:
+        size_metadata = {
+            "total_size_gb": f"{repo.metadata.cache.total_size_gb:.2f}",
+            "total_csize_gb": f"{repo.metadata.cache.total_csize_gb:.2f}",
+            "unique_csize_gb": f"{repo.metadata.cache.unique_csize_gb:.2f}",
+        }
+
     return BorgRepoTableItem(
         repo_path=repo.path.as_posix(),
         backup_target_path=repo.backup_target.as_posix(),
@@ -37,6 +53,7 @@ def _convert_repo_to_table_item(repo: BorgRepo) -> BorgRepoTableItem:
         hostname=repo.hostname,
         last_backup=repo.last_backup.isoformat() if repo.last_backup else None,
         last_s3_sync=repo.last_s3_sync.isoformat() if repo.last_s3_sync else None,
+        **size_metadata,
     )
 
 

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -45,6 +45,7 @@ def get_repo_info(repo_path: str | None, repo_name: str | None) -> None:
         raise ValueError("Repository must be local to view info")
     repo.info()
     repo.collect_json_info()
+    dynamodb.update_repo(repo)
 
 
 def list_repos() -> None:
@@ -80,4 +81,5 @@ def perform_daily_backup(repo_path: str) -> None:
     repo.prune()
     repo.compact()
     repo.sync_with_s3()
+    repo.collect_json_info()
     dynamodb.update_repo(repo)

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -44,6 +44,7 @@ def get_repo_info(repo_path: str | None, repo_name: str | None) -> None:
     if validator.repo_is_local(repo) is False:
         raise ValueError("Repository must be local to view info")
     repo.info()
+    repo.collect_json_info()
 
 
 def list_repos() -> None:

--- a/src/borgboi/rich_utils.py
+++ b/src/borgboi/rich_utils.py
@@ -1,9 +1,64 @@
 import subprocess as sp
+from functools import cached_property
 
+from pydantic import BaseModel, Field, computed_field
+from rich.columns import Columns
 from rich.console import Console
+from rich.panel import Panel
 from rich.text import Text
 
+GIBIBYTES_IN_GIGABYTE = 0.93132257461548
+
 console = Console(record=True)
+
+
+class Stats(BaseModel):
+    total_chunks: int
+    total_csize: int = Field(description="Compressed size")
+    total_size: int = Field(description="Original size")
+    total_unique_chunks: int
+    unique_csize: int = Field(description="Deduplicated size")
+    unique_size: int
+
+
+class RepoCache(BaseModel):
+    path: str
+    stats: Stats
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def total_size_gb(self) -> float:
+        """Original size in gigabytes."""
+        return self.stats.total_size / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def total_csize_gb(self) -> float:
+        """Compressed size in gigabytes."""
+        return self.stats.total_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def unique_csize_gb(self) -> float:
+        """Deduplicated size in gigabytes."""
+        return self.stats.unique_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE
+
+
+class Encryption(BaseModel):
+    mode: str
+
+
+class Repository(BaseModel):
+    id: str
+    last_modified: str
+    location: str
+
+
+class RepoInfo(BaseModel):
+    cache: RepoCache
+    encryption: Encryption
+    repository: Repository
+    security_dir: str
 
 
 def _print_cmd_parts(cmd_parts: list[str]) -> None:
@@ -55,6 +110,33 @@ def run_and_log_sp_popen(
         console.print(f":x: [bold red]{error_message} - Return code: {proc.returncode}[/]")
         raise sp.CalledProcessError(returncode=proc.returncode, cmd=cmd_parts)
     console.print(f":heavy_check_mark: [bold green]{success_message}[/]")
+
+
+def run_and_output_repo_info(cmd_parts: list[str]) -> None:
+    """
+    Run a subprocess.Popen command and logs the output to the console.
+    This output is wrapped by a rich console.status context manager to
+    display a spinner while the command is running.
+
+    Args:
+        cmd_parts (list[str]): command inputs to pass to subprocess.Popen
+
+    Raises:
+        sp.CalledProcessError: Error raised if command exit code isn't 0 or 1
+    """
+    _print_cmd_parts(cmd_parts)
+    result = sp.run(cmd_parts, capture_output=True, text=True)  # noqa: PLW1510, S603
+    if result.returncode != 0 and result.returncode != 1:
+        console.print(f":x: [bold red]{result.stderr} - Return code: {result.returncode}[/]")
+        raise sp.CalledProcessError(returncode=result.returncode, cmd=cmd_parts)
+    foo = RepoInfo.model_validate_json(result.stdout)
+    console.print(foo)
+    panels: list[Panel] = []
+    panels.append(Panel(f"{foo.cache.total_size_gb:.2f} GB", title="Total Size", expand=False))
+    panels.append(Panel(f"{foo.cache.total_csize_gb:.2f} GB", title="Compressed Size", expand=False))
+    panels.append(Panel(f"{foo.cache.unique_csize_gb:.2f} GB", title="Deduplicated Size", expand=False))
+    columns = Columns(panels)
+    console.print(columns)
 
 
 def output_init_instructions(repo_path: str) -> None:

--- a/src/borgboi/rich_utils.py
+++ b/src/borgboi/rich_utils.py
@@ -1,67 +1,12 @@
 import subprocess as sp
-from functools import cached_property
 
-from pydantic import BaseModel, Field, computed_field
-from rich.columns import Columns
 from rich.console import Console
-from rich.panel import Panel
 from rich.text import Text
-
-GIBIBYTES_IN_GIGABYTE = 0.93132257461548
 
 console = Console(record=True)
 
 
-class Stats(BaseModel):
-    total_chunks: int
-    total_csize: int = Field(description="Compressed size")
-    total_size: int = Field(description="Original size")
-    total_unique_chunks: int
-    unique_csize: int = Field(description="Deduplicated size")
-    unique_size: int
-
-
-class RepoCache(BaseModel):
-    path: str
-    stats: Stats
-
-    @computed_field  # type: ignore[prop-decorator]
-    @cached_property
-    def total_size_gb(self) -> float:
-        """Original size in gigabytes."""
-        return self.stats.total_size / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE
-
-    @computed_field  # type: ignore[prop-decorator]
-    @cached_property
-    def total_csize_gb(self) -> float:
-        """Compressed size in gigabytes."""
-        return self.stats.total_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE
-
-    @computed_field  # type: ignore[prop-decorator]
-    @cached_property
-    def unique_csize_gb(self) -> float:
-        """Deduplicated size in gigabytes."""
-        return self.stats.unique_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE
-
-
-class Encryption(BaseModel):
-    mode: str
-
-
-class Repository(BaseModel):
-    id: str
-    last_modified: str
-    location: str
-
-
-class RepoInfo(BaseModel):
-    cache: RepoCache
-    encryption: Encryption
-    repository: Repository
-    security_dir: str
-
-
-def _print_cmd_parts(cmd_parts: list[str]) -> None:
+def print_cmd_parts(cmd_parts: list[str]) -> None:
     cmd = Text.assemble(("Preparing to execute: ", "orange3"), (" ".join(cmd_parts), "bold blue"))
     console.print(cmd)
 
@@ -90,7 +35,7 @@ def run_and_log_sp_popen(
     Raises:
         sp.CalledProcessError: Error raised if command exit code isn't 0 or 1
     """
-    _print_cmd_parts(cmd_parts)
+    print_cmd_parts(cmd_parts)
     proc = sp.Popen(cmd_parts, stdout=sp.PIPE, stderr=sp.PIPE)  # noqa: S603
     status = status_message
 
@@ -112,31 +57,8 @@ def run_and_log_sp_popen(
     console.print(f":heavy_check_mark: [bold green]{success_message}[/]")
 
 
-def run_and_output_repo_info(cmd_parts: list[str]) -> None:
-    """
-    Run a subprocess.Popen command and logs the output to the console.
-    This output is wrapped by a rich console.status context manager to
-    display a spinner while the command is running.
-
-    Args:
-        cmd_parts (list[str]): command inputs to pass to subprocess.Popen
-
-    Raises:
-        sp.CalledProcessError: Error raised if command exit code isn't 0 or 1
-    """
-    _print_cmd_parts(cmd_parts)
-    result = sp.run(cmd_parts, capture_output=True, text=True)  # noqa: PLW1510, S603
-    if result.returncode != 0 and result.returncode != 1:
-        console.print(f":x: [bold red]{result.stderr} - Return code: {result.returncode}[/]")
-        raise sp.CalledProcessError(returncode=result.returncode, cmd=cmd_parts)
-    foo = RepoInfo.model_validate_json(result.stdout)
-    console.print(foo)
-    panels: list[Panel] = []
-    panels.append(Panel(f"{foo.cache.total_size_gb:.2f} GB", title="Total Size", expand=False))
-    panels.append(Panel(f"{foo.cache.total_csize_gb:.2f} GB", title="Compressed Size", expand=False))
-    panels.append(Panel(f"{foo.cache.unique_csize_gb:.2f} GB", title="Deduplicated Size", expand=False))
-    columns = Columns(panels)
-    console.print(columns)
+def output_obj(obj: object) -> None:
+    console.print(obj)
 
 
 def output_init_instructions(repo_path: str) -> None:

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.opentofu.org/opentofu/aws" {
   constraints = "~> 5.82"
   hashes = [
     "h1:65B6GjFmKobkuaO58AcDPUu/otnTR7qRTynWTgU5A7Q=",
+    "h1:9QRxRf9iCT7UPymoHdcif0DcKwKAM/PiQ75VBrl9W+o=",
     "zh:0c662b1f27119941e2329155070c8a81f6979e3d5e98296949f373c46487d84e",
     "zh:56cbaeaf050174bb9ba9a00f31fe441365ffece6ad39254885c9d4e6517e27e3",
     "zh:6e7f66c9f9955deb9ce0a2ae4b6df366b3b6bc3e23bca1fcdd4351ecab3ec907",


### PR DESCRIPTION
Add additional data structures to store the output of `borg info`. Currently, only storing the total size, total compressed size, and deduplicated size in Dynamo.

This value is updated in the table when the `borgboi repo-info` command is ran and as part of the `borgboi daily-backup` command.

### 🤖 Summary
This pull request includes several changes to enhance the functionality and data handling of the `borgboi` backup tool. The most significant changes involve adding new commands, introducing new data models, and updating the DynamoDB integration to store additional metadata.

New commands and documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R27): Updated to mark the command to print information on the borg repo as complete and added placeholders for new commands such as deleting, downloading, and restoring borg repos, along with additional tests.

New data models and properties:

* [`src/borgboi/backups.py`](diffhunk://#diff-a1302eede3d7d1ba2819db5811ba97ad5b1baa58e64944e9d6b3cb6a9b3f637cR1-R68): Added new classes `Stats`, `RepoCache`, `Encryption`, `Repository`, and `RepoInfo` to manage repository metadata. Introduced computed properties to convert sizes to gigabytes.
* [`src/borgboi/backups.py`](diffhunk://#diff-a1302eede3d7d1ba2819db5811ba97ad5b1baa58e64944e9d6b3cb6a9b3f637cR77): Added a `metadata` attribute to the `BorgRepo` class to store repository information.

Enhanced repository information collection:

* [`src/borgboi/backups.py`](diffhunk://#diff-a1302eede3d7d1ba2819db5811ba97ad5b1baa58e64944e9d6b3cb6a9b3f637cR236-R252): Added a new method `collect_json_info` to the `BorgRepo` class to collect repository information in JSON format using the `borg info --json` command.

DynamoDB integration updates:

* [`src/borgboi/dynamodb.py`](diffhunk://#diff-f7f322fc267a6d419cf867cfeefd543129c8db2d0d7f208afcde4c5bc04ed8e0R20-R22): Updated the `BorgRepoTableItem` class and `_convert_repo_to_table_item` function to include new size metadata fields. [[1]](diffhunk://#diff-f7f322fc267a6d419cf867cfeefd543129c8db2d0d7f208afcde4c5bc04ed8e0R20-R22) [[2]](diffhunk://#diff-f7f322fc267a6d419cf867cfeefd543129c8db2d0d7f208afcde4c5bc04ed8e0R35-R47) [[3]](diffhunk://#diff-f7f322fc267a6d419cf867cfeefd543129c8db2d0d7f208afcde4c5bc04ed8e0R56)

Orchestrator updates:

* [`src/borgboi/orchestrator.py`](diffhunk://#diff-84a5b203686439695ea6770c3f126fc014b880bf3c70eae5acef4c1a0550df36R47-R48): Modified the `get_repo_info` and `perform_daily_backup` functions to call `collect_json_info` and update the repository information in DynamoDB. [[1]](diffhunk://#diff-84a5b203686439695ea6770c3f126fc014b880bf3c70eae5acef4c1a0550df36R47-R48) [[2]](diffhunk://#diff-84a5b203686439695ea6770c3f126fc014b880bf3c70eae5acef4c1a0550df36R84)