### PR TITLE
feat: add ability to create exclusion list for each borg repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ terraform/.terraform
 **/*.tfstate.backup
 .dmypy.json
 .envrc
-
+exclude.txt

--- a/src/borgboi/backups.py
+++ b/src/borgboi/backups.py
@@ -9,8 +9,8 @@ from pydantic.types import DirectoryPath, NewPath
 
 from borgboi import rich_utils
 
-BORGBOI_DIR_NAME = ".borgboi"
-EXCLUDE_FILENAME = "exclude.txt"
+BORGBOI_DIR_NAME = getenv("BORGBOI_DIR_NAME", ".borgboi")
+EXCLUDE_FILENAME = "excludes.txt"
 GIBIBYTES_IN_GIGABYTE = 0.93132257461548
 
 

--- a/src/borgboi/backups.py
+++ b/src/borgboi/backups.py
@@ -9,6 +9,8 @@ from pydantic.types import DirectoryPath, NewPath
 
 from borgboi import rich_utils
 
+BORGBOI_DIR_NAME = ".borgboi"
+EXCLUDE_FILENAME = "exclude.txt"
 GIBIBYTES_IN_GIGABYTE = 0.93132257461548
 
 
@@ -138,22 +140,8 @@ class BorgRepo(BaseModel):
             "--compression=zstd,1",
             "--exclude-caches",
             "--exclude-nodump",
-            "--exclude",
-            "'home/*/.cache/*'",
-            "--exclude",
-            "'Users/zachfuller/*/.cache/*'",  # NOTE: hardcoded path
-            "--exclude",
-            "'Users/zachfuller/Library/Caches/*'",  # NOTE: hardcoded path
-            "--exclude",
-            "'Users/zachfuller/*/__pycache__/*'",  # NOTE: hardcoded path
-            "--exclude",
-            "'Users/zachfuller/*/.venv/*'",  # NOTE: hardcoded path
-            "--exclude",
-            "'Users/zachfuller/.vscode/*'",  # NOTE: hardcoded path
-            "--exclude",
-            "'Users/zachfuller/*/.rustup/toolchains/*'",  # NOTE: hardcoded path
-            "--exclude",
-            "'Users/zachfuller/.npm/_cacache/*'",  # NOTE: hardcoded path
+            "--exclude-from",
+            f"{(Path.home() / BORGBOI_DIR_NAME / f'{self.name}_{EXCLUDE_FILENAME}').as_posix()}",
             f"{self.path.as_posix()}::{title}",
             self.backup_target.as_posix(),
         ]
@@ -261,7 +249,7 @@ class BorgRepo(BaseModel):
 
         https://borgbackup.readthedocs.io/en/stable/usage/key.html#borg-key-export
         """
-        borgboi_repo_keys_dir = Path.home() / ".borgboi"
+        borgboi_repo_keys_dir = Path.home() / BORGBOI_DIR_NAME
         borgboi_repo_keys_dir.mkdir(exist_ok=True)
         key_export_path = borgboi_repo_keys_dir / f"{self.name}-encrypted-key-backup.txt"
         cmd_parts = ["borg", "key", "export", "--paper", self.path.as_posix(), key_export_path.as_posix()]

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -26,6 +26,15 @@ def create_repo(repo_path: str, backup_target: str) -> None:
 
 
 @cli.command()
+@click.option("--repo-path", "-r", required=True, type=click.Path(exists=False), prompt=True)
+@click.option("--exclusions-source", "-x", required=True, type=click.Path(exists=True, dir_okay=False))
+def create_exclusions(repo_path: str, exclusions_source: str) -> None:
+    """Create a new exclusions list for a Borg repository."""
+    repo = orchestrator.lookup_repo(repo_path, None)
+    orchestrator.create_excludes_list(repo.name, exclusions_source)
+
+
+@cli.command()
 def list_repos() -> None:
     """Create a new Borg repository."""
     orchestrator.list_repos()

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -16,10 +16,15 @@ def create_excludes_list(repo_name: str, excludes_source_file: str) -> Path:
     """
     if validator.exclude_list_created(repo_name) is True:
         raise ValueError("Exclude list already created")
+    borgboi_dir = Path.home() / BORGBOI_DIR_NAME
+    if borgboi_dir.exists() is False:
+        borgboi_dir.mkdir()
     console.print("Creating Borg exclude list...")
+
     src_file = Path(excludes_source_file)
-    dest_file = Path.home() / BORGBOI_DIR_NAME / f"{repo_name}_{EXCLUDE_FILENAME}"
+    dest_file = borgboi_dir / f"{repo_name}_{EXCLUDE_FILENAME}"
     shutil.copy(src_file, dest_file.as_posix())
+
     if dest_file.exists():
         console.print(f"Exclude list created at [bold cyan]{dest_file.as_posix()}[/]")
     else:

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -10,7 +10,7 @@ from borgboi.backups import BORGBOI_DIR_NAME, EXCLUDE_FILENAME, BorgRepo
 from borgboi.rich_utils import console, output_repo_info
 
 
-def create_excludes_list(repo_name: str, excludes_source_file: str) -> None:
+def create_excludes_list(repo_name: str, excludes_source_file: str) -> Path:
     """
     Create the Borg exclude list.
     """
@@ -24,6 +24,7 @@ def create_excludes_list(repo_name: str, excludes_source_file: str) -> None:
         console.print(f"Exclude list created at [bold cyan]{dest_file.as_posix()}[/]")
     else:
         raise FileNotFoundError("Excludes list not created")
+    return dest_file
 
 
 def create_borg_repo(path: str, backup_path: str, passphrase_env_var_name: str, name: str) -> BorgRepo:

--- a/src/borgboi/validator.py
+++ b/src/borgboi/validator.py
@@ -1,7 +1,13 @@
 import socket
+from pathlib import Path
 
-from borgboi.backups import BorgRepo
+from borgboi.backups import BORGBOI_DIR_NAME, EXCLUDE_FILENAME, BorgRepo
 
 
 def repo_is_local(repo: BorgRepo) -> bool:
     return repo.hostname == socket.gethostname()
+
+
+def exclude_list_created(repo_name: str) -> bool:
+    exclude_file = Path.home() / BORGBOI_DIR_NAME / f"{repo_name}_{EXCLUDE_FILENAME}"
+    return exclude_file.exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def _common_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BORG_NEW_PASSPHRASE", "test")
     monkeypatch.setenv("BORG_S3_BUCKET", "test")
     monkeypatch.setenv("BORG_DYNAMODB_TABLE", DYNAMO_TABLE_NAME)
+    monkeypatch.setenv("BORGBOI_DIR_NAME", ".borgboi")
 
 
 @pytest.fixture

--- a/tests/data/excludes.txt
+++ b/tests/data/excludes.txt
@@ -1,0 +1,8 @@
+# Comment line
+home/*/junk
+*.tmp
+fm:aa:something/*
+re:^home/[^/]+\.tmp/
+sh:home/*/.thumbnails
+# Example with spaces, no need to escape as it is processed by borg
+some file with spaces.txt

--- a/tests/orchestrator_test.py
+++ b/tests/orchestrator_test.py
@@ -51,7 +51,7 @@ def test_lookup_repo(repo_path: str | None, repo_name: str | None, monkeypatch: 
 
 @pytest.mark.usefixtures("create_dynamodb_table")
 def test_restore_archive(repo_storage_dir: Path, backup_target_dir: Path) -> None:
-    from borgboi.orchestrator import create_borg_repo
+    from borgboi.orchestrator import create_borg_repo, create_excludes_list
 
     # Create and initialize Borg repo in a tmp directory
     repo = create_borg_repo(
@@ -64,6 +64,8 @@ def test_restore_archive(repo_storage_dir: Path, backup_target_dir: Path) -> Non
     json_file_path = json_file.as_posix()
     with json_file.open("w") as f:
         json.dump(file_data, f, indent=2)
+    # Create an exclusion list for the repo
+    create_excludes_list(repo.name, "tests/data/excludes.txt")
     # Create an archive of the source directory
     archive_name = repo.create_archive()
     # delete data.json

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ wheels = [
 
 [[package]]
 name = "borgboi"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
BREAKING CHANGE: An exclusion file must exist before a daily backup or archive can be created. There is a new borgboi command to create this exclusions list. After it's created, it will be persisted. Closes #21