### PR TITLE
33 support deleting individual archives

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       # Configure a constant location for the uv cache
         UV_CACHE_DIR: /tmp/.uv-cache
-        UV_VERSION: 0.5.29
+        UV_VERSION: 0.6.0
         FORCE_COLOR: 1
 
     steps:
@@ -47,6 +47,6 @@ jobs:
       run: |
         mkdir ~/.aws && touch ~/.aws/credentials && echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
         source .venv/bin/activate
-        pytest -v
+        just test
     - name: Minimize uv cache
       run: uv cache prune --ci

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ default:
 test:
     uv run pytest -v --capture=tee-sys
     rm -rf {{ test_restore_dir }}
+    @echo {{ BOLD + GREEN }}'✔️ All tests passed!'{{ NORMAL }}
 
 # run pytest test suite with coverage
 test-cov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest-socket>=0.7.0",
     "pytest-sugar>=1.0.0",
     "ruff>=0.8.6",
+    "rust-just>=1.39.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/borgboi/backups.py
+++ b/src/borgboi/backups.py
@@ -388,7 +388,7 @@ class BorgRepo(BaseModel):
                 f"{self.repo_posix_path}::{archive_name}",
             ]
         else:
-            rich_utils.confirm_deletion(archive_name)
+            rich_utils.confirm_deletion(self.name, archive_name)
             cmd_parts = [
                 "borg",
                 "delete",

--- a/src/borgboi/backups.py
+++ b/src/borgboi/backups.py
@@ -369,6 +369,46 @@ class BorgRepo(BaseModel):
             use_stderr=True,
         )
 
+    def delete_archive(self, archive_name: str, dry_run: bool) -> None:
+        """
+        Delete an archive from the Borg repository.
+
+        https://borgbackup.readthedocs.io/en/stable/usage/delete.html
+        """
+        if dry_run:
+            cmd_parts = [
+                "borg",
+                "delete",
+                "-v",
+                "--dry-run",  # include dry-run flag
+                "--list",
+                "--force",
+                "--checkpoint-interval",
+                "10",
+                f"{self.repo_posix_path}::{archive_name}",
+            ]
+        else:
+            rich_utils.confirm_deletion(archive_name)
+            cmd_parts = [
+                "borg",
+                "delete",
+                "-v",
+                "--list",
+                "--force",
+                "--checkpoint-interval",
+                "10",
+                f"{self.repo_posix_path}::{archive_name}",
+            ]
+
+        rich_utils.run_and_log_sp_popen(
+            cmd_parts=cmd_parts,
+            status_message="[bold blue]Deleting archive[/]",
+            success_message="Archive deleted successfully",
+            error_message="Error deleting archive",
+            spinner="toggle",
+            use_stderr=True,
+        )
+
     def sync_with_s3(self) -> None:
         """
         Sync the local Borg repository with an S3 bucket.

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -86,6 +86,15 @@ def extract_archive(repo_path: str, archive_name: str) -> None:
 
 
 @cli.command()
+@click.option("--repo-path", "-r", required=True, type=click.Path(exists=True))
+@click.option("--archive-name", "-a", required=True, prompt=True)
+@click.option("--dry-run", is_flag=True, show_default=True, default=False, help="Perform a dry run of the deletion")
+def delete_archive(repo_path: str, archive_name: str, dry_run: bool) -> None:
+    """Delete a Borg archive from the repository."""
+    orchestrator.delete_archive(repo_path, archive_name, dry_run)
+
+
+@cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
 @click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
 @click.option("--dry-run", is_flag=True, show_default=True, default=False, help="Perform a dry run of the deletion")

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -91,16 +91,7 @@ def extract_archive(repo_path: str, archive_name: str) -> None:
 @click.option("--dry-run", is_flag=True, show_default=True, default=False, help="Perform a dry run of the deletion")
 def delete_repo(repo_path: str | None, repo_name: str | None, dry_run: bool) -> None:
     """Delete a Borg repository."""
-    repo = orchestrator.lookup_repo(repo_path, repo_name)
-    repo.collect_json_info()
-    repo.info()
-    console.print(
-        repo.model_dump(
-            exclude={"passphrase", "passphrase_env_var_name", "repo_posix_path", "backup_target_posix_path"}
-        )
-    )
-    click.confirm("Are you sure you want to delete this repository?", abort=True)
-    repo.delete(dry_run)
+    orchestrator.delete_borg_repo(repo_path, repo_name, dry_run)
 
 
 def main() -> None:

--- a/src/borgboi/dynamodb.py
+++ b/src/borgboi/dynamodb.py
@@ -152,6 +152,18 @@ def get_repo_by_name(repo_name: str) -> BorgRepo:
     return _convert_table_item_to_repo(BorgRepoTableItem(**response["Items"][0]))  # type: ignore
 
 
+def delete_repo(repo: BorgRepo) -> None:
+    """
+    Delete a Borg repository from the DynamoDB table.
+
+    Args:
+        repo (BorgRepo): Borg repository to delete
+    """
+    table = boto3.resource("dynamodb", config=boto_config).Table(environ["BORG_DYNAMODB_TABLE"])
+    table.delete_item(Key={"repo_path": repo.path})
+    console.print(f"Deleted repo from DynamoDB table: [bold cyan]{repo.repo_posix_path}[/]")
+
+
 def update_repo(repo: BorgRepo) -> None:
     """
     Update a Borg repository in the DynamoDB table.

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -64,7 +64,10 @@ def delete_borg_repo(repo_path: str | None, repo_name: str | None, dry_run: bool
     if validator.repo_is_local(repo) is False:
         raise ValueError("Repository must be local to delete")
     repo.delete(dry_run)
-    dynamodb.delete_repo(repo)
+    if not dry_run:
+        dynamodb.delete_repo(repo)
+        # NOTE: Space is NOT reclaimed on disk until the 'compact' command is ran
+        repo.compact()
 
 
 def lookup_repo(repo_path: str | None, repo_name: str | None) -> BorgRepo:
@@ -147,3 +150,6 @@ def restore_archive(repo_path: str, archive_name: str) -> None:
 def delete_archive(repo_path: str, archive_name: str, dry_run: bool) -> None:
     repo = lookup_repo(repo_path, None)
     repo.delete_archive(archive_name, dry_run)
+    if not dry_run:
+        # NOTE: Space is NOT reclaimed on disk until the 'compact' command is ran
+        repo.compact()

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -66,8 +66,6 @@ def delete_borg_repo(repo_path: str | None, repo_name: str | None, dry_run: bool
     repo.delete(dry_run)
     if not dry_run:
         dynamodb.delete_repo(repo)
-        # NOTE: Space is NOT reclaimed on disk until the 'compact' command is ran
-        repo.compact()
 
 
 def lookup_repo(repo_path: str | None, repo_name: str | None) -> BorgRepo:

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -59,6 +59,14 @@ def create_borg_repo(path: str, backup_path: str, passphrase_env_var_name: str, 
     return new_repo
 
 
+def delete_borg_repo(repo_path: str | None, repo_name: str | None, dry_run: bool) -> None:
+    repo = lookup_repo(repo_path, repo_name)
+    if validator.repo_is_local(repo) is False:
+        raise ValueError("Repository must be local to delete")
+    repo.delete(dry_run)
+    dynamodb.delete_repo(repo)
+
+
 def lookup_repo(repo_path: str | None, repo_name: str | None) -> BorgRepo:
     if repo_path is not None:
         return dynamodb.get_repo_by_path(repo_path)

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -142,3 +142,8 @@ def perform_daily_backup(repo_path: str) -> None:
 def restore_archive(repo_path: str, archive_name: str) -> None:
     repo = lookup_repo(repo_path, None)
     repo.extract(archive_name)
+
+
+def delete_archive(repo_path: str, archive_name: str, dry_run: bool) -> None:
+    repo = lookup_repo(repo_path, None)
+    repo.delete_archive(archive_name, dry_run)

--- a/src/borgboi/rich_utils.py
+++ b/src/borgboi/rich_utils.py
@@ -126,9 +126,25 @@ def output_repo_info(
     console.rule(f"[bold magenta]Repo ID:[/] [magenta]{repo_id}[/]", style="blue")
 
 
-def confirm_deletion(repo_name: str) -> None:
-    resp = console.input(f"[red]Type [bold]{repo_name}[/] to confirm deletion: ")
-    if resp.lower() == repo_name.lower():
+def confirm_deletion(repo_name: str, archive_name: str = "") -> None:
+    """
+    Prompts the user to confirm deletion of a Borg repository or archive.
+
+    Args:
+        repo_name (str): name of the repository to be deleted
+        archive_name (str, optional): name of the archive to be deleted. Defaults to "".
+
+    Raises:
+        ValueError: If the user does not confirm deletion.
+
+    Returns:
+        None: Indicates the confirmation process is complete.
+    """
+    confirmation_key = repo_name
+    if archive_name:
+        confirmation_key = f"{repo_name}::{archive_name}"
+    resp = console.input(f"[red]Type [bold]{confirmation_key}[/] to confirm deletion: ")
+    if resp.lower() == confirmation_key.lower():
         return None
     console.print("Deletion aborted.")
     raise ValueError("Deletion aborted.")

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -32,3 +32,12 @@ def test_create_repo(
     )
     assert result.exit_code == 0
     assert "Created new Borg repo at" in result.stdout
+
+
+def test_delete_repo(
+    monkeypatch: pytest.MonkeyPatch, repo_storage_dir: Path, backup_target_dir: Path, borg_repo: BorgRepo
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["delete-repo", "--repo-path", str(repo_storage_dir)], input=borg_repo.name)
+    assert result.exit_code == 0
+    assert "Repository deleted successfully\nDeleted repo from DynamoDB table" in result.stdout

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -31,4 +31,4 @@ def test_create_repo(
         input="BORG_PASSPHRASE\nTestRepo\n",
     )
     assert result.exit_code == 0
-    assert f"Created new Borg repo at {borg_repo.repo_posix_path}" in result.stdout
+    assert "Created new Borg repo at" in result.stdout

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -40,4 +40,5 @@ def test_delete_repo(
     runner = CliRunner()
     result = runner.invoke(cli, ["delete-repo", "--repo-path", str(repo_storage_dir)], input=borg_repo.name)
     assert result.exit_code == 0
-    assert "Repository deleted successfully\nDeleted repo from DynamoDB table" in result.stdout
+    assert "Repository deleted successfully" in result.stdout
+    assert "Deleted repo from DynamoDB table" in result.stdout

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from borgboi import orchestrator
+from borgboi.backups import BorgRepo
+from borgboi.cli import cli
+
+
+def test_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert result.stdout.startswith("Usage: cli [OPTIONS] COMMAND [ARGS]")
+
+
+def test_create_repo(
+    monkeypatch: pytest.MonkeyPatch, repo_storage_dir: Path, backup_target_dir: Path, borg_repo: BorgRepo
+) -> None:
+    def mock_create_borg_repo(*args: Any, **kwargs: Any) -> BorgRepo:
+        return borg_repo
+
+    monkeypatch.setattr(orchestrator, "create_borg_repo", mock_create_borg_repo)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["create-repo", "--repo-path", str(repo_storage_dir), "--backup-target", str(backup_target_dir)],
+        input="BORG_PASSPHRASE\nTestRepo\n",
+    )
+    assert result.exit_code == 0
+    assert f"Created new Borg repo at {borg_repo.repo_posix_path}" in result.stdout

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from borgboi import orchestrator
 from borgboi.backups import BorgRepo
 from borgboi.cli import cli
+from tests.orchestrator_test import EXCLUDES_SRC
 
 
 def test_help() -> None:
@@ -34,11 +35,29 @@ def test_create_repo(
     assert "Created new Borg repo at" in result.stdout
 
 
-def test_delete_repo(
-    monkeypatch: pytest.MonkeyPatch, repo_storage_dir: Path, backup_target_dir: Path, borg_repo: BorgRepo
-) -> None:
+def test_delete_repo(repo_storage_dir: Path, borg_repo: BorgRepo) -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["delete-repo", "--repo-path", str(repo_storage_dir)], input=borg_repo.name)
     assert result.exit_code == 0
     assert "Repository deleted successfully" in result.stdout
     assert "Deleted repo from DynamoDB table" in result.stdout
+
+
+def test_delete_archive(repo_storage_dir: Path, borg_repo: BorgRepo) -> None:
+    from borgboi.orchestrator import create_excludes_list
+
+    # Create an exclusion list for the repo
+    new_excludes_file = create_excludes_list(borg_repo.name, EXCLUDES_SRC)
+    # Create an archive to be deleted in this test
+    archive_name = borg_repo.create_archive()
+    new_excludes_file.unlink()
+
+    runner = CliRunner()
+    deletion_confirm_input = f"{borg_repo.name}::{archive_name}"
+    result = runner.invoke(
+        cli,
+        ["delete-archive", "--repo-path", str(repo_storage_dir), "--archive-name", archive_name],
+        input=deletion_confirm_input,
+    )
+    assert result.exit_code == 0
+    assert "Archive deleted successfully" in result.stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,15 @@ import os
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import boto3
 import pytest
 from moto import mock_aws
 from mypy_boto3_dynamodb import DynamoDBClient
 from mypy_boto3_s3 import S3Client
+
+from borgboi.backups import BorgRepo
 
 DYNAMO_TABLE_NAME = "borg-repos-test"
 
@@ -98,3 +101,11 @@ def repo_storage_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 @pytest.fixture
 def backup_target_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return tmp_path_factory.mktemp("borgboi-test-backup-target")
+
+
+@pytest.fixture
+def borg_repo(repo_storage_dir: Path, backup_target_dir: Path, create_dynamodb_table: None) -> BorgRepo:
+    from borgboi.orchestrator import create_borg_repo
+
+    repo_name = uuid4().hex[0:5]
+    return create_borg_repo(repo_storage_dir.as_posix(), backup_target_dir.as_posix(), "BORG_NEW_PASSPHRASE", repo_name)

--- a/tests/orchestrator_test.py
+++ b/tests/orchestrator_test.py
@@ -10,14 +10,6 @@ from borgboi.backups import BorgRepo
 EXCLUDES_SRC = "tests/data/excludes.txt"
 
 
-@pytest.fixture
-def borg_repo(repo_storage_dir: Path, backup_target_dir: Path, create_dynamodb_table: None) -> BorgRepo:
-    from borgboi.orchestrator import create_borg_repo
-
-    repo_name = uuid4().hex[0:5]
-    return create_borg_repo(repo_storage_dir.as_posix(), backup_target_dir.as_posix(), "BORG_NEW_PASSPHRASE", repo_name)
-
-
 @pytest.mark.usefixtures("create_dynamodb_table")
 def test_create_borg_repo(repo_storage_dir: Path, backup_target_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from borgboi.orchestrator import create_borg_repo

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,7 @@ dev = [
     { name = "pytest-socket" },
     { name = "pytest-sugar" },
     { name = "ruff" },
+    { name = "rust-just" },
 ]
 
 [package.metadata]
@@ -54,6 +55,7 @@ dev = [
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.8.6" },
+    { name = "rust-just", specifier = ">=1.39.0" },
 ]
 
 [[package]]
@@ -858,6 +860,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/7d/7b461ab0e2404293c0627125bb70ac642c2e8d55bf590f6fce85f508f1b2/ruff-0.9.6-py3-none-win32.whl", hash = "sha256:194d8402bceef1b31164909540a597e0d913c0e4952015a5b40e28c146121b5d", size = 9949214 },
     { url = "https://files.pythonhosted.org/packages/ee/30/c3cee10f915ed75a5c29c1e57311282d1a15855551a64795c1b2bbe5cf37/ruff-0.9.6-py3-none-win_amd64.whl", hash = "sha256:03482d5c09d90d4ee3f40d97578423698ad895c87314c4de39ed2af945633caa", size = 10999914 },
     { url = "https://files.pythonhosted.org/packages/e8/a8/d71f44b93e3aa86ae232af1f2126ca7b95c0f515ec135462b3e1f351441c/ruff-0.9.6-py3-none-win_arm64.whl", hash = "sha256:0e2bb706a2be7ddfea4a4af918562fdc1bcb16df255e5fa595bbd800ce322a5a", size = 10177499 },
+]
+
+[[package]]
+name = "rust-just"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/e5/37254d353a23f567ac218ddd2c461337fafe3a43d44dcd6f0c8e72d096f4/rust_just-1.39.0.tar.gz", hash = "sha256:247d0b293924cc8089a73428c9c03a3c2c0627bb8f205addb976ded0681f0dac", size = 1395439 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/9e/c7151bfa84c1cd3ac4c11a60d1a2f074b7a244ae96959d968e8b9e8e3f29/rust_just-1.39.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3845ab10254c994ddebcf489b30c53a24c1d11585c9e0eeaf1cb0da422bee87f", size = 1781993 },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/c93ef08567835356033bee162c2e5e06b018811f5188b94ef3e74dafe7eb/rust_just-1.39.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fd5c12118a8d65266ccdacfbc24bab26f77d509caaf263095cb96611ea6ce7e8", size = 1652880 },
+    { url = "https://files.pythonhosted.org/packages/f3/e7/22647f9c18537046940b3b4159377665912acccbacedd775917610c0390d/rust_just-1.39.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:428d07b1e798777c4e9a8c245539d72743be095558010f0a86823e1c442930f9", size = 1771788 },
+    { url = "https://files.pythonhosted.org/packages/d5/1f/2a36afad5eeca6756fc8c87e08d102cdadf8e4b31c5f8bcb6f12c109b5b4/rust_just-1.39.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:135a7a65a8641b00a2fe7f3156a97ab7052e4830a922a71e67ca4e38ccd54cd2", size = 1778377 },
+    { url = "https://files.pythonhosted.org/packages/97/5b/45effb44bbfab892774a239446920cfb9b3d999921fe7cff3d99b36394a7/rust_just-1.39.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94eb45e585fda019f7f9cbac198e10e31f81c704371887cbdec9b7a1ae2e0d29", size = 1896235 },
+    { url = "https://files.pythonhosted.org/packages/b5/12/7e88a7e917c2e933846a32a2f537786829b48c827a6029e85943d5eeadc0/rust_just-1.39.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de4a8566ca1eb87b5ff2669a6dd9474b16977c5d712534a5a9c7a950271da2d0", size = 1954347 },
+    { url = "https://files.pythonhosted.org/packages/9a/36/5dc917a2c0a0b66f0cc4bb0be4985090deefa33433dd869649a4ce2bc8f3/rust_just-1.39.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7ecd8fd862729c243498951caa54d778ff480c2524039280ff3ebb9a64299f", size = 2450909 },
+    { url = "https://files.pythonhosted.org/packages/da/fc/b9224b354da8a89b38cd4145ec0e9e089635a45c1459231e349647cdad64/rust_just-1.39.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:576229024d2ef8fc696d5a049ecd0d8f3d9b920a32e76f65e95840d24d804101", size = 1895058 },
+    { url = "https://files.pythonhosted.org/packages/0b/ef/985cb93c9dd36f9bc41f26b3ce6d420c69fb18166ac61783bced2c328f75/rust_just-1.39.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c1cd9240e2c1b352d7ccc6b89ce84fcc0352f15bb9660cdc6bc34802b36251b6", size = 1767816 },
+    { url = "https://files.pythonhosted.org/packages/50/43/fc644746a7479fadbe6878ae9fa1da83860104d1e64a49de47306fa1a591/rust_just-1.39.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d6eff0461df7e36eba6e7f0addf16ef98563cf8cb483e4c8393be5456d6af5c6", size = 1791992 },
+    { url = "https://files.pythonhosted.org/packages/32/d9/6924547c02afba3a49b14f53bed09b54d4292016b830f366d7ed1f80288a/rust_just-1.39.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0dfcc49a5fa126ba923b58e48921fd117e429660495577a854494c6ced3134c9", size = 1884357 },
+    { url = "https://files.pythonhosted.org/packages/15/96/7e8d3795588c2e8e629f9f0d9cdd0cf1ba1bef5bf9c8b64aae33c78f1993/rust_just-1.39.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:826203ad02c869ad8621993a608adb01394ef9c9c9ca6aa7dd7875b1f272aa46", size = 1936706 },
+    { url = "https://files.pythonhosted.org/packages/23/28/2492c4b7c8f0e526f52a263f20b951880387f992151bbc46c6c8914786a8/rust_just-1.39.0-py3-none-win32.whl", hash = "sha256:dcef0926b287449e853b878f6f34759a797d017cefb83afbcd74820d37259b78", size = 1577519 },
+    { url = "https://files.pythonhosted.org/packages/6f/c2/1d576be1ca714df4a90255cfbcb4ec06d9aafbf7b14924c2881a8596a68e/rust_just-1.39.0-py3-none-win_amd64.whl", hash = "sha256:3139f3f76434a8ebbf35b213d149e647c4d9546312b438e262df7ec41e7ef7bc", size = 1705761 },
 ]
 
 [[package]]


### PR DESCRIPTION
### To Do

- [x] Add command to delete individual archive
- [x] Delete Borg repo from Dynamo table if repo is deleted
- [x] Add test for delete repo
- [x] Add test for delete archive
- [x] Run `compact` command after deleting archive ~~or repo~~

### 🤖 Summary
This pull request introduces several changes to enhance the functionality and testing of the Borg backup system. The most significant updates include the addition of new commands for deleting archives and repositories, improvements to the testing framework, and updates to dependencies.

### New Features:

* Added `delete_archive` method to `backups.py` to enable the deletion of specific archives from the Borg repository.
* Introduced `delete_archive` command in `cli.py` to allow users to delete archives via the command line.
* Added `delete_borg_repo` method to `orchestrator.py` for deleting entire Borg repositories, including DynamoDB cleanup.

### Testing Enhancements:

* Added new tests for `delete_repo` and `delete_archive` commands in `cli_test.py` to ensure proper functionality.
* Created a `borg_repo` fixture in `conftest.py` to simplify the setup of Borg repositories in tests.

### Dependency Updates:

* Updated `pyproject.toml` to include `rust-just>=1.39.0` for managing task automation.
* Updated `.github/workflows/test.yml` to use `just test` instead of `pytest -v` for running tests.

These changes collectively enhance the functionality, maintainability, and test coverage of the Borg backup system.

Closes #33 