### PR TITLE
New Commands for Modifying Repo Exclusion Files

### DIFF
--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -31,7 +31,7 @@ Options:
 ```text
 Usage: bb append-excludes [OPTIONS]
 
-  Display the exclude patterns for a repository.
+  Append a new exclusion pattern to the repository.
 
 Options:
   -n, --repo-name TEXT          Name of the repository  [required]

--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -26,6 +26,32 @@ Options:
 
 ```
 
+## `append-excludes`
+
+```text
+Usage: bb append-excludes [OPTIONS]
+
+  Display the exclude patterns for a repository.
+
+Options:
+  -n, --repo-name TEXT          Name of the repository  [required]
+  -x, --exclusion-pattern TEXT  Exclusion pattern to add  [required]
+
+```
+
+## `modify-excludes`
+
+```text
+Usage: bb modify-excludes [OPTIONS]
+
+  Delete a line from a repository's excludes file.
+
+Options:
+  -n, --repo-name TEXT           Name of the repository  [required]
+  -D, --delete-line-num INTEGER  Line number to delete  [required]
+
+```
+
 ## `list-repos`
 
 ```text

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -112,7 +112,7 @@ def delete_repo(repo_path: str | None, repo_name: str | None, dry_run: bool) -> 
 @click.option("--repo-name", "-n", required=True, type=str, help="Name of the repository")
 @click.option("--exclusion-pattern", "-x", required=True, type=str, help="Exclusion pattern to add")
 def append_excludes(repo_name: str, exclusion_pattern: str) -> None:
-    """Append new exclusion pattern to the excludes fle for a repository."""
+    """Append new exclusion pattern to the excludes file for a repository."""
     try:
         excludes_file = orchestrator.get_excludes_file(repo_name)
         orchestrator.append_to_excludes_file(excludes_file, exclusion_pattern)

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -112,7 +112,7 @@ def delete_repo(repo_path: str | None, repo_name: str | None, dry_run: bool) -> 
 @click.option("--repo-name", "-n", required=True, type=str, help="Name of the repository")
 @click.option("--exclusion-pattern", "-x", required=True, type=str, help="Exclusion pattern to add")
 def append_excludes(repo_name: str, exclusion_pattern: str) -> None:
-    """Display the exclude patterns for a repository."""
+    """Append new exclusion pattern to the excludes fle for a repository."""
     try:
         excludes_file = orchestrator.get_excludes_file(repo_name)
         orchestrator.append_to_excludes_file(excludes_file, exclusion_pattern)

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -108,6 +108,34 @@ def delete_repo(repo_path: str | None, repo_name: str | None, dry_run: bool) -> 
     orchestrator.delete_borg_repo(repo_path, repo_name, dry_run)
 
 
+@cli.command()
+@click.option("--repo-name", "-n", required=True, type=str, help="Name of the repository")
+@click.option("--exclusion-pattern", "-x", required=True, type=str, help="Exclusion pattern to add")
+def append_excludes(repo_name: str, exclusion_pattern: str) -> None:
+    """Display the exclude patterns for a repository."""
+    try:
+        excludes_file = orchestrator.get_excludes_file(repo_name)
+        orchestrator.append_to_excludes_file(excludes_file, exclusion_pattern)
+    except FileNotFoundError as e:
+        console.print(f"[bold red]Error:[/] {e}")
+    except Exception as e:
+        console.print(f"[bold red]Error:[/] An unexpected error occurred: {e}")
+
+
+@cli.command()
+@click.option("--repo-name", "-n", required=True, type=str, help="Name of the repository")
+@click.option("--delete-line-num", "-D", required=True, type=int, help="Line number to delete")
+def modify_excludes(repo_name: str, delete_line_num: int) -> None:
+    """Delete a line from a repository's excludes file."""
+    try:
+        excludes_file = orchestrator.get_excludes_file(repo_name)
+        orchestrator.remove_from_excludes_file(excludes_file, delete_line_num)
+    except FileNotFoundError as e:
+        console.print(f"[bold red]Error:[/] {e}")
+    except Exception as e:
+        console.print(f"[bold red]Error:[/] An unexpected error occurred: {e}")
+
+
 def main() -> None:
     cli()
 

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -222,16 +222,17 @@ def extract_repo_key(repo_path: str) -> Path:
 
 def get_excludes_file(repo_name: str) -> Path:
     """
-    Get the content of the excludes file for a repository.
+    Get the Path of the excludes file for a repository.
 
     Args:
         repo_name: Name of the repository
 
     Returns:
-        str: The content of the excludes file
+        Path: The pathlib Path of the excludes file
 
     Raises:
         FileNotFoundError: If the excludes file does not exist
+        ValueError: If the repository is not local
     """
     # Validate repository is local
     repo = lookup_repo(None, repo_name)
@@ -250,7 +251,7 @@ def get_excludes_file(repo_name: str) -> Path:
 
 def append_to_excludes_file(excludes_path: Path, new_content: str) -> None:
     """
-    Update the content of the excludes file for a repository.
+    Append new content to the excludes file for a repository.
 
     Args:
         excludes_path: Path to the excludes file
@@ -285,9 +286,9 @@ def remove_from_excludes_file(excludes_path: Path, line_number: int) -> None:
     # Read the content of the excludes file
     with excludes_path.open("r") as f:
         lines = f.readlines()
+    if not validator.valid_line(lines, line_number):
+        raise ValueError(f"Line number {line_number} is not valid")
     # Remove the specified line
-    if line_number < 1 or line_number > len(lines):
-        raise ValueError(f"Line number {line_number} is out of range")
     lines.pop(line_number - 1)
     # Write the updated content back to the excludes file
     with excludes_path.open("w") as f:

--- a/src/borgboi/rich_utils.py
+++ b/src/borgboi/rich_utils.py
@@ -180,6 +180,7 @@ def render_excludes_file(excludes_file_path: str, lines_to_highlight: set[int] |
 
     Args:
         excludes_file_path (str): Path to the excludes file.
+        lines_to_highlight (set[int], optional): Set of line numbers to highlight. Defaults to None.
 
     Returns:
         None
@@ -187,4 +188,5 @@ def render_excludes_file(excludes_file_path: str, lines_to_highlight: set[int] |
     syntax = Syntax.from_path(
         excludes_file_path, line_numbers=True, theme="dracula", padding=1, highlight_lines=lines_to_highlight
     )
-    console.print(syntax)
+    panel = Panel(syntax, title="Excludes File", expand=False)
+    console.print(panel)

--- a/src/borgboi/rich_utils.py
+++ b/src/borgboi/rich_utils.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from rich.columns import Columns
 from rich.console import Console
 from rich.panel import Panel
+from rich.syntax import Syntax
 from rich.table import Table
 
 from borgboi.clients.utils.borg_logs import (
@@ -171,3 +172,19 @@ def render_cmd_output_lines(
 
     console.rule(f":heavy_check_mark: [bold {TEXT_COLOR}]{success_msg}[/]", style=ruler_color)
     console.print("")
+
+
+def render_excludes_file(excludes_file_path: str, lines_to_highlight: set[int] | None = None) -> None:
+    """
+    Render the contents of the excludes file to the console.
+
+    Args:
+        excludes_file_path (str): Path to the excludes file.
+
+    Returns:
+        None
+    """
+    syntax = Syntax.from_path(
+        excludes_file_path, line_numbers=True, theme="dracula", padding=1, highlight_lines=lines_to_highlight
+    )
+    console.print(syntax)

--- a/src/borgboi/validator.py
+++ b/src/borgboi/validator.py
@@ -77,3 +77,18 @@ def parse_logs(
                 except ValidationError:
                     log_msg = LogMessage.model_validate_json(log)
         yield log_msg
+
+
+def valid_line(lines: list[str], line_num: int) -> bool:
+    """
+    Check if the line number is valid for the given lines.
+
+    Args:
+        lines (list[str]): List of lines.
+        line_num (int): Line number to check.
+
+    Returns:
+        bool: True if the line number is valid, False otherwise.
+    """
+    # line numbers start from 1 so 0 is invalid
+    return 0 < line_num < len(lines)

--- a/src/borgboi/validator.py
+++ b/src/borgboi/validator.py
@@ -91,4 +91,4 @@ def valid_line(lines: list[str], line_num: int) -> bool:
         bool: True if the line number is valid, False otherwise.
     """
     # line numbers start from 1 so 0 is invalid
-    return 0 < line_num < len(lines)
+    return 0 < line_num <= len(lines)


### PR DESCRIPTION
Closes #62 

### :robot: Summary

This pull request introduces new functionalities for handling exclude patterns in repositories and includes corresponding updates to the documentation, CLI commands, orchestrator functions, and tests. The most important changes include adding new CLI commands for appending and modifying exclude patterns, updating the orchestrator to support these operations, and adding tests to ensure the new functionality works correctly.

New CLI commands for exclude patterns:

* [`docs/pages/commands.md`](diffhunk://#diff-41bf007156ca972df7f8d482c21b1ea97331a18748f8aa73be4c80c40a2294a0R29-R54): Added documentation for the new `append-excludes` and `modify-excludes` commands.
* [`src/borgboi/cli.py`](diffhunk://#diff-1f55a84fea225b183e6dd3c01fb7f0fd1741614dbc068256760dcb2e5fa8571bR111-R138): Implemented the `append_excludes` and `modify_excludes` commands to handle adding and removing exclude patterns in repositories.

Orchestrator updates:

* [`src/borgboi/orchestrator.py`](diffhunk://#diff-84a5b203686439695ea6770c3f126fc014b880bf3c70eae5acef4c1a0550df36R221-R297): Added functions `get_excludes_file`, `append_to_excludes_file`, and `remove_from_excludes_file` to manage exclude patterns in the orchestrator.

Utility updates:

* [`src/borgboi/rich_utils.py`](diffhunk://#diff-2c18766cecadbf5b7bd1396c4d7c0360851ef44393e1ef4c6097dafe0b1edfc8R175-R192): Added `render_excludes_file` function to render the contents of the excludes file to the console with optional line highlighting.

Tests for new functionality:

* [`tests/orchestrator_test.py`](diffhunk://#diff-68878f84a618b4c2e5ace236776f201ca88d0d0bba68199905457ef08efec62cR104-R163): Added tests for `get_excludes_file`, `append_to_excludes_file`, and `remove_from_excludes_file` to ensure the new exclude pattern functionalities work as expected.