### PR TITLE
feat: New Command to Restore BorgBoi Repo from S3

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1,0 +1,774 @@
+{
+    "files": {
+        "./src/borgboi/cli.py": [
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 0,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 8,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 89,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 5,
+                    "lineCount": 3
+                }
+            }
+        ],
+        "./src/borgboi/clients/borg.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/borgboi/clients/dynamodb.py": [
+            {
+                "code": "reportImportCycles",
+                "range": {
+                    "startColumn": 0,
+                    "endColumn": 0,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportTypedDictNotRequiredAccess",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/borgboi/clients/s3.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/borgboi/orchestrator.py": [
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/borgboi/rich_utils.py": [
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnnecessaryComparison",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./tests/cli_test.py": [
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateUsage",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 94,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./tests/conftest.py": [
+            {
+                "code": "reportUnusedFunction",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 5,
+                    "lineCount": 25
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./tests/orchestrator_test.py": [
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateUsage",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            }
+        ]
+    }
+}

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -422,24 +422,6 @@
                 }
             }
         ],
-        "./src/borgboi/clients/s3.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/borgboi/orchestrator.py": [
             {
                 "code": "reportUnusedCallResult",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "python.languageServer": "None",
+    "python.analysis.typeCheckingMode": "off",
+    "mcp": {
+        "inputs": [],
+        "servers": {
+            "mcp-server-time": {
+                "command": "python",
+                "args": [
+                    "-m",
+                    "mcp_server_time",
+                    "--local-timezone=America/Los_Angeles"
+                ],
+                "env": {}
+            }
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ default:
 
 # run pytest test suite
 test:
-    uv run pytest -vv --capture=tee-sys
+    uv run pytest -vv
     rm -rf {{ test_restore_dir }}
     @echo {{ BOLD + GREEN }}'✔️ All tests passed!'{{ NORMAL }}
 

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ default:
 
 # run pytest test suite
 test:
-    uv run pytest -vv
+    uv run pytest -vv --capture=tee-sys --diff-symbols
     rm -rf {{ test_restore_dir }}
     @echo {{ BOLD + GREEN }}'✔️ All tests passed!'{{ NORMAL }}
 

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ default:
 
 # run pytest test suite
 test:
-    uv run pytest -v --capture=tee-sys
+    uv run pytest -vv --capture=tee-sys
     rm -rf {{ test_restore_dir }}
     @echo {{ BOLD + GREEN }}'✔️ All tests passed!'{{ NORMAL }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "basedpyright>=1.29.1",
     "boto3-stubs[essential]>=1.35.92",
     "moto[dynamodb,iam,s3]>=5.0.26",
     "mypy[faster-cache]>=1.14.1",
@@ -63,6 +64,13 @@ filterwarnings = [
     "ignore::DeprecationWarning:botocore.auth:425", # handles: 'DeprecationWarning: datetime.datetime.utcnow()'
 ]
 
+
+[tool.basedpyright]
+include = [
+    "src/**",
+    "tests/**",
+]
+typeCheckingMode = "recommended"
 
 [tool.mypy]
 plugins = [

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -139,7 +139,8 @@ def modify_excludes(repo_name: str, delete_line_num: int) -> None:
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
 @click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
-def restore_repo(repo_path: str | None, repo_name: str | None) -> None:
+@click.option("--dry-run", is_flag=True, show_default=True, default=False, help="Perform a dry run of the restore")
+def restore_repo(repo_path: str | None, repo_name: str | None, dry_run: bool) -> None:
     """Restore a Borg repository by name or path by downloading it from S3."""
     repo = orchestrator.lookup_repo(repo_path, repo_name)
     if repo.metadata and repo.metadata.cache:
@@ -148,10 +149,7 @@ def restore_repo(repo_path: str | None, repo_name: str | None) -> None:
         )
     else:
         console.print(f"Repository found: [bold cyan]{repo.path}[/]")
-    _ = click.confirm("Perform dry run of restore process?", abort=True)
-    orchestrator.restore_repo(repo, dry_run=True)
-    _ = click.confirm(f"Confirm you want to restore the repository to: {repo.safe_path}", abort=True)
-    orchestrator.restore_repo(repo, dry_run=False)
+    orchestrator.restore_repo(repo, dry_run)
 
 
 def main() -> None:

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -136,6 +136,24 @@ def modify_excludes(repo_name: str, delete_line_num: int) -> None:
         console.print(f"[bold red]Error:[/] An unexpected error occurred: {e}")
 
 
+@cli.command()
+@click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+def restore_repo(repo_path: str | None, repo_name: str | None) -> None:
+    """Restore a Borg repository by name or path by downloading it from S3."""
+    repo = orchestrator.lookup_repo(repo_path, repo_name)
+    if repo.metadata and repo.metadata.cache:
+        console.print(
+            f"Repository found: [bold cyan]{repo.path} - Total size: {repo.metadata.cache.total_size_gb} GB[/]"
+        )
+    else:
+        console.print(f"Repository found: [bold cyan]{repo.path}[/]")
+    _ = click.confirm("Perform dry run of restore process?", abort=True)
+    orchestrator.restore_repo(repo, dry_run=True)
+    _ = click.confirm(f"Confirm you want to restore the repository to: {repo.safe_path}", abort=True)
+    orchestrator.restore_repo(repo, dry_run=False)
+
+
 def main() -> None:
     cli()
 

--- a/src/borgboi/clients/s3.py
+++ b/src/borgboi/clients/s3.py
@@ -44,3 +44,50 @@ def sync_with_s3(repo_path: str, repo_name: str) -> Generator[str]:
     returncode = proc.wait()
     if returncode != 0:
         raise sp.CalledProcessError(returncode=proc.returncode, cmd=cmd)
+
+
+def restore_from_s3_dry_run(repo_path: str, repo_name: str) -> Generator[str]:
+    """
+    Restore a Borg repository from an S3 bucket while yielding the output line by line.
+
+    Args:
+        repo_path (str): posix path to the Borg repository
+        repo_name (str): name of the Borg repository
+
+    Raises:
+        sp.CalledProcessError: If the command returns a non-zero exit code
+
+    Yields:
+        Generator[str]: stdout of S3 sync command line by line
+    """
+    sync_source = f"s3://{environ['BORG_S3_BUCKET']}/{repo_name}"
+    s3_destination_uri = repo_path
+    cmd = [
+        "aws",
+        "s3",
+        "--dryrun",
+        "sync",
+        sync_source,
+        s3_destination_uri,
+    ]
+
+    proc = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE)  # noqa: S603
+    out_stream = proc.stdout
+
+    if not out_stream:
+        raise ValueError("stdout is None")
+
+    while out_stream.readable():
+        line = out_stream.readline()
+        if not line:
+            if proc.stdout:
+                proc.stdout.close()
+            if proc.stderr:
+                proc.stderr.close()
+            break
+        yield line.decode("utf-8")
+
+    # stdout no longer readable so wait for return code
+    returncode = proc.wait()
+    if returncode != 0:
+        raise sp.CalledProcessError(returncode=proc.returncode, cmd=cmd)

--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -2,8 +2,9 @@ from datetime import datetime
 from functools import cached_property
 from os import getenv
 from pathlib import Path
+from typing import Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from borgboi.clients.borg import RepoInfo
 
@@ -22,6 +23,13 @@ class BorgBoiRepo(BaseModel):
     os_platform: str = Field(min_length=3)
     last_backup: datetime | None = None
     metadata: RepoInfo | None
+
+    @field_validator("os_platform")
+    @classmethod
+    def validate_os_platform(cls, v: str) -> str:
+        if v not in {"Linux", "Darwin"}:
+            raise ValueError("os_platform must be either 'Linux' or 'Darwin'. Windows is not supported.")
+        return v
 
     @computed_field  # mypy: ignore[prop-decorator]
     @cached_property

--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from functools import cached_property
 from os import getenv
+from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from borgboi.clients.borg import RepoInfo
 
@@ -20,3 +22,24 @@ class BorgBoiRepo(BaseModel):
     os_platform: str = Field(min_length=3)
     last_backup: datetime | None = None
     metadata: RepoInfo | None
+
+    @computed_field  # mypy: ignore[prop-decorator]
+    @cached_property
+    def safe_path(self) -> str:
+        """
+        Path to the Borg repository, replacing platform specific home
+        directories with the current system's pattern.
+
+        Returns:
+            str: posix path to the Borg repository
+        """
+        if self.path.startswith("/home/"):
+            child_path = self.path.split("/home/")[-1]
+            path_no_username = child_path.split("/", 1)[-1]
+            return (Path.home() / path_no_username).as_posix()
+        elif self.path.startswith("/Users/"):
+            child_path = self.path.split("/Users/")[-1]
+            path_no_username = child_path.split("/", 1)[-1]
+            return (Path.home() / child_path).as_posix()
+        else:
+            return Path(self.path).as_posix()

--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from functools import cached_property
 from os import getenv
 from pathlib import Path
-from typing import Literal
 
 from pydantic import BaseModel, Field, computed_field, field_validator
 
@@ -41,13 +40,10 @@ class BorgBoiRepo(BaseModel):
         Returns:
             str: posix path to the Borg repository
         """
-        if self.path.startswith("/home/"):
-            child_path = self.path.split("/home/")[-1]
-            path_no_username = child_path.split("/", 1)[-1]
-            return (Path.home() / path_no_username).as_posix()
-        elif self.path.startswith("/Users/"):
-            child_path = self.path.split("/Users/")[-1]
-            path_no_username = child_path.split("/", 1)[-1]
-            return (Path.home() / child_path).as_posix()
+        # FIXME: Handle scenario when username is different on the two platforms
+        if self.path.startswith("/home/") and self.os_platform == "Darwin":
+            return self.path.replace("/home/", "/Users/")
+        elif self.path.startswith("/Users/") and self.os_platform == "Linux":
+            return self.path.replace("/Users/", "/home/")
         else:
             return Path(self.path).as_posix()

--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -28,7 +28,7 @@ class BorgBoiRepo(BaseModel):
     @classmethod
     def validate_os_platform(cls, v: str) -> str:
         if v not in {"Linux", "Darwin"}:
-            raise ValueError("os_platform must be either 'Linux' or 'Darwin'. Windows is not supported.")
+            raise ValueError(f"os_platform must be either 'Linux' or 'Darwin'. '{v}' is not supported.")
         return v
 
     @computed_field  # mypy: ignore[prop-decorator]

--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -41,9 +41,9 @@ class BorgBoiRepo(BaseModel):
             str: posix path to the Borg repository
         """
         # FIXME: Handle scenario when username is different on the two platforms
-        if self.path.startswith("/home/") and self.os_platform == "Darwin":
-            return self.path.replace("/home/", "/Users/")
-        elif self.path.startswith("/Users/") and self.os_platform == "Linux":
-            return self.path.replace("/Users/", "/home/")
+        if self.path.startswith("/home/") and self.os_platform != "Linux":
+            return self.path.replace("home/", "Users/", 1)
+        elif self.path.startswith("/Users/") and self.os_platform != "Darwin":
+            return self.path.replace("Users/", "home/", 1)
         else:
             return Path(self.path).as_posix()

--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from functools import cached_property
 from os import getenv
 from pathlib import Path
+from platform import system
 
 from pydantic import BaseModel, Field, computed_field, field_validator
 
@@ -40,10 +41,11 @@ class BorgBoiRepo(BaseModel):
         Returns:
             str: posix path to the Borg repository
         """
+        current_os = system()
         # FIXME: Handle scenario when username is different on the two platforms
-        if self.path.startswith("/home/") and self.os_platform != "Linux":
+        if self.path.startswith("/home/") and current_os != "Linux":
             return self.path.replace("home/", "Users/", 1)
-        elif self.path.startswith("/Users/") and self.os_platform != "Darwin":
+        elif self.path.startswith("/Users/") and current_os != "Darwin":
             return self.path.replace("Users/", "home/", 1)
         else:
             return Path(self.path).as_posix()

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -183,6 +183,33 @@ def perform_daily_backup(repo_path: str) -> None:
     dynamodb.update_repo(repo)
 
 
+def restore_repo(repo: BorgBoiRepo, dry_run: bool = True) -> None:
+    """
+    Restore a Borg repository from S3.
+    """
+    if validator.repo_is_local(repo):
+        raise ValueError("Repository already exists locally")
+
+    if dry_run:
+        # Perform dry run and display results to user
+        rich_utils.render_cmd_output_lines(
+            "Syncing repo with S3 bucket",
+            "S3 sync completed successfully",
+            s3.restore_from_s3_dry_run(repo.safe_path, repo.name),
+            spinner="arrow",
+            ruler_color=COLOR_HEX.blue,
+        )
+    else:
+        # Perform actual sync
+        rich_utils.render_cmd_output_lines(
+            "Syncing repo with S3 bucket",
+            "S3 sync completed successfully",
+            s3.sync_with_s3(repo.safe_path, repo.name),
+            spinner="arrow",
+            ruler_color=COLOR_HEX.blue,
+        )
+
+
 def restore_archive(repo_path: str, archive_name: str) -> None:
     repo = lookup_repo(repo_path, None)
     for log_msg in borg.extract(repo.path, archive_name):

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -183,31 +183,21 @@ def perform_daily_backup(repo_path: str) -> None:
     dynamodb.update_repo(repo)
 
 
-def restore_repo(repo: BorgBoiRepo, dry_run: bool = True) -> None:
+def restore_repo(repo: BorgBoiRepo, dry_run: bool) -> None:
     """
     Restore a Borg repository from S3.
     """
     if validator.repo_is_local(repo):
         raise ValueError("Repository already exists locally")
 
-    if dry_run:
-        # Perform dry run and display results to user
-        rich_utils.render_cmd_output_lines(
-            "Syncing repo with S3 bucket",
-            "S3 sync completed successfully",
-            s3.restore_from_s3_dry_run(repo.safe_path, repo.name),
-            spinner="arrow",
-            ruler_color=COLOR_HEX.blue,
-        )
-    else:
-        # Perform actual sync
-        rich_utils.render_cmd_output_lines(
-            "Syncing repo with S3 bucket",
-            "S3 sync completed successfully",
-            s3.sync_with_s3(repo.safe_path, repo.name),
-            spinner="arrow",
-            ruler_color=COLOR_HEX.blue,
-        )
+    status = "Performing dry run of S3 sync..." if dry_run else "Restoring repo from S3..."
+    rich_utils.render_cmd_output_lines(
+        status,
+        "S3 sync completed successfully",
+        s3.restore_from_s3(repo.safe_path, repo.name, dry_run),
+        spinner="arrow",
+        ruler_color=COLOR_HEX.blue,
+    )
 
 
 def restore_archive(repo_path: str, archive_name: str) -> None:

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -33,7 +33,6 @@ def borg_repo_mac() -> BorgBoiRepo:
 
 @pytest.mark.skipif(system() == "Linux", reason="Test only runs on non-Linux systems")
 def test_safe_path_convert_linux_repo(borg_repo_linux: BorgBoiRepo) -> None:
-    assert borg_repo_linux.safe_path.startswith("/Users/")
     expected_path_parts = ["Users", "$USER", "borg-repos", "repo"]
     safe_path_parts = borg_repo_linux.safe_path.split("/")
     assert len(safe_path_parts) == len(expected_path_parts)
@@ -45,7 +44,6 @@ def test_safe_path_convert_linux_repo(borg_repo_linux: BorgBoiRepo) -> None:
 
 @pytest.mark.skipif(system() == "Darwin", reason="Test only runs on non-Mac systems")
 def test_safe_path_convert_mac_repo(borg_repo_mac: BorgBoiRepo) -> None:
-    assert borg_repo_mac.safe_path.startswith("/home/")
     expected_path_parts = ["home", "$USER", "borg-repos", "repo"]
     safe_path_parts = borg_repo_mac.safe_path.split("/")
     assert len(safe_path_parts) == len(expected_path_parts)

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -13,7 +13,7 @@ def borg_repo_linux() -> BorgBoiRepo:
         backup_target="/home/zach/Documents",
         name="docs-repo",
         hostname="ubuntu-desktop",
-        os_platform="linux",
+        os_platform="Linux",
         metadata=None,
     )
 
@@ -26,7 +26,7 @@ def borg_repo_mac() -> BorgBoiRepo:
         backup_target="/Users/zachfuller/Pictures",
         name="pictures-repo",
         hostname="zach-macbook",
-        os_platform="mac",
+        os_platform="Darwin",
         metadata=None,
     )
 

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,0 +1,55 @@
+from platform import system
+
+import pytest
+
+from borgboi.models import BorgBoiRepo
+
+
+@pytest.fixture
+def borg_repo_linux() -> BorgBoiRepo:
+    """Fixture for a Linux based Borg repository."""
+    return BorgBoiRepo(
+        path="/home/zach/borg-repos/repo",
+        backup_target="/home/zach/Documents",
+        name="docs-repo",
+        hostname="ubuntu-desktop",
+        os_platform="linux",
+        metadata=None,
+    )
+
+
+@pytest.fixture
+def borg_repo_mac() -> BorgBoiRepo:
+    """Fixture for a Mac based Borg repository."""
+    return BorgBoiRepo(
+        path="/Users/zachfuller/borg-repos/repo",
+        backup_target="/Users/zachfuller/Pictures",
+        name="pictures-repo",
+        hostname="zach-macbook",
+        os_platform="mac",
+        metadata=None,
+    )
+
+
+@pytest.mark.skipif(system() == "Linux", reason="Test only runs on non-Linux systems")
+def test_safe_path_convert_linux_repo(borg_repo_linux: BorgBoiRepo) -> None:
+    assert borg_repo_linux.safe_path.startswith("/Users/")
+    expected_path_parts = ["Users", "$USER", "borg-repos", "repo"]
+    safe_path_parts = borg_repo_linux.safe_path.split("/")
+    assert len(safe_path_parts) == len(expected_path_parts)
+    for part in range(len(expected_path_parts)):
+        if expected_path_parts[part] == "$USER":
+            continue
+        assert safe_path_parts[part] == expected_path_parts[part]
+
+
+@pytest.mark.skipif(system() == "Darwin", reason="Test only runs on non-Mac systems")
+def test_safe_path_convert_mac_repo(borg_repo_mac: BorgBoiRepo) -> None:
+    assert borg_repo_mac.safe_path.startswith("/home/")
+    expected_path_parts = ["home", "$USER", "borg-repos", "repo"]
+    safe_path_parts = borg_repo_mac.safe_path.split("/")
+    assert len(safe_path_parts) == len(expected_path_parts)
+    for part in range(len(expected_path_parts)):
+        if expected_path_parts[part] == "$USER":
+            continue
+        assert safe_path_parts[part] == expected_path_parts[part]

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -34,7 +34,7 @@ def borg_repo_mac() -> BorgBoiRepo:
 @pytest.mark.skipif(system() == "Linux", reason="Test only runs on non-Linux systems")
 def test_safe_path_convert_linux_repo(borg_repo_linux: BorgBoiRepo) -> None:
     expected_path_parts = ["Users", "$USER", "borg-repos", "repo"]
-    safe_path_parts = borg_repo_linux.safe_path.split("/")
+    safe_path_parts = borg_repo_linux.safe_path.split("/")[1:]
     assert len(safe_path_parts) == len(expected_path_parts)
     for part in range(len(expected_path_parts)):
         if expected_path_parts[part] == "$USER":
@@ -45,7 +45,7 @@ def test_safe_path_convert_linux_repo(borg_repo_linux: BorgBoiRepo) -> None:
 @pytest.mark.skipif(system() == "Darwin", reason="Test only runs on non-Mac systems")
 def test_safe_path_convert_mac_repo(borg_repo_mac: BorgBoiRepo) -> None:
     expected_path_parts = ["home", "$USER", "borg-repos", "repo"]
-    safe_path_parts = borg_repo_mac.safe_path.split("/")
+    safe_path_parts = borg_repo_mac.safe_path.split("/")[1:]
     assert len(safe_path_parts) == len(expected_path_parts)
     for part in range(len(expected_path_parts)):
         if expected_path_parts[part] == "$USER":

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/18/f5e488eac4960ad9a2e71b95f0d91cf93a982c7f68aa90e4e0554f0bc37e/basedpyright-1.29.1.tar.gz", hash = "sha256:06bbe6c3b50ab4af20f80e154049477a50d8b81d2522eadbc9f472f2f92cd44b", size = 21773469, upload-time = "2025-04-23T13:29:42.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/1b/1bb837bbb7e259928f33d3c105dfef4f5349ef08b3ef45576801256e3234/basedpyright-1.29.1-py3-none-any.whl", hash = "sha256:b7eb65b9d4aaeeea29a349ac494252032a75a364942d0ac466d7f07ddeacc786", size = 11397959, upload-time = "2025-04-23T13:29:38.106Z" },
+]
+
+[[package]]
 name = "borgboi"
 version = "1.3.0"
 source = { editable = "." }
@@ -47,6 +59,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "boto3-stubs", extra = ["essential"] },
     { name = "moto", extra = ["dynamodb", "s3"] },
     { name = "mypy", extra = ["faster-cache"] },
@@ -75,6 +88,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.29.1" },
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35.92" },
     { name = "moto", extras = ["dynamodb", "iam", "s3"], specifier = ">=5.0.26" },
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.14.1" },
@@ -692,6 +706,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "22.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/5b/6c5f973765b96793d4e4d03684bcbd273b17e471ecc7e9bec4c32b595ebd/nodejs_wheel_binaries-22.15.0.tar.gz", hash = "sha256:ff81aa2a79db279c2266686ebcb829b6634d049a5a49fc7dc6921e4f18af9703", size = 8054, upload-time = "2025-04-23T16:57:40.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/a8/a32e5bb99e95c536e7dac781cffab1e7e9f8661b8ee296b93df77e4df7f9/nodejs_wheel_binaries-22.15.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:aa16366d48487fff89446fb237693e777aa2ecd987208db7d4e35acc40c3e1b1", size = 50514526, upload-time = "2025-04-23T16:57:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e8/eb024dbb3a7d3b98c8922d1c306be989befad4d2132292954cb902f43b07/nodejs_wheel_binaries-22.15.0-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:a54bb3fee9170003fa8abc69572d819b2b1540344eff78505fcc2129a9175596", size = 51409179, upload-time = "2025-04-23T16:57:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0f/baa968456c3577e45c7d0e3715258bd175dcecc67b683a41a5044d5dae40/nodejs_wheel_binaries-22.15.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:867121ccf99d10523f6878a26db86e162c4939690e24cfb5bea56d01ea696c93", size = 57364460, upload-time = "2025-04-23T16:57:15.725Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a2/977f63cd07ed8fc27bc0d0cd72e801fc3691ffc8cd40a51496ff18a6d0a2/nodejs_wheel_binaries-22.15.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ab0fbcda2ddc8aab7db1505d72cb958f99324b3834c4543541a305e02bfe860", size = 57889101, upload-time = "2025-04-23T16:57:19.643Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7f/57b9c24a4f0d25490527b043146aa0fdff2d8fdc82f90667cdaf6f00cfc9/nodejs_wheel_binaries-22.15.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2bde1d8e00cd955b9ce9ee9ac08309923e2778a790ee791b715e93e487e74bfd", size = 59190817, upload-time = "2025-04-23T16:57:23.875Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7f/970acbe33b81c22b3c7928f52e32347030aa46d23d779cf781cf9a9cf557/nodejs_wheel_binaries-22.15.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:acdd4ef73b6701aab9fbe02ac5e104f208a5e3c300402fa41ad7bc7f49499fbf", size = 60220316, upload-time = "2025-04-23T16:57:28.276Z" },
+    { url = "https://files.pythonhosted.org/packages/07/4c/030243c04bb60f0de66c2d7ee3be289c6d28ef09113c06ffa417bdfedf8f/nodejs_wheel_binaries-22.15.0-py2.py3-none-win_amd64.whl", hash = "sha256:51deaf13ee474e39684ce8c066dfe86240edb94e7241950ca789befbbbcbd23d", size = 40718853, upload-time = "2025-04-23T16:57:32.651Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/49/011d472814af4fabeaab7d7ce3d5a1a635a3dadc23ae404d1f546839ecb3/nodejs_wheel_binaries-22.15.0-py2.py3-none-win_arm64.whl", hash = "sha256:01a3fe4d60477f93bf21a44219db33548c75d7fed6dc6e6f4c05cf0adf015609", size = 36436645, upload-time = "2025-04-23T16:57:36.326Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #85 

### 🤖 Summary

This pull request introduces several changes to enhance functionality, improve error handling, and configure development tools. Key updates include adding a new `restore_repo` CLI command, implementing repository restoration from S3, and configuring static type checking tools. Below is a breakdown of the most significant changes:

### New Features
* Added a `restore_repo` CLI command in `src/borgboi/cli.py` to restore Borg repositories from S3 by name or path, with optional dry-run support.
* Introduced the `restore_from_s3` function in `src/borgboi/clients/s3.py` to handle S3 sync operations for repository restoration, including dry-run functionality and error handling for non-zero exit codes.
* Implemented the `restore_repo` function in `src/borgboi/orchestrator.py` to coordinate repository restoration workflows, including validation and rendering of command output.

### Enhancements
* Added a `safe_path` computed property to the `BorgBoiRepo` model in `src/borgboi/models.py` to normalize and resolve platform-specific home directory paths.

### Development Tooling
* Configured `basedpyright` for static type checking in `pyproject.toml`, including specifying `src/**` and `tests/**` as included paths and setting the type checking mode to "recommended."
* Updated `.vscode/settings.json` to disable the Python language server and add configurations for a custom command (`mcp-server-time`).