### PR TITLE
Enhance Archive Commands

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,13 @@
+name: gitleaks
+on: [pull_request, push, workflow_dispatch]
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,7 @@
 name: gitleaks
 on: [pull_request, push, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   scan:
     name: gitleaks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       # Configure a constant location for the uv cache
         UV_CACHE_DIR: /tmp/.uv-cache
-        UV_VERSION: 0.6.5
+        UV_VERSION: 0.7.9
         UV_PYTHON_PREFERENCE: only-system
         UV_PYTHON_DOWNLOADS: never
         FORCE_COLOR: 1

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ terraform/.terraform
 .dmypy.json
 .envrc
 exclude.txt
+output.txt
+*.txt

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -49,9 +49,10 @@ def list_archives(repo_path: str | None, repo_name: str | None) -> None:
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
 @click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
 @click.option("--archive-name", "-a", required=True, type=str)
-def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_name: str) -> None:
+@click.option("--output", "-o", required=False, type=str, default="stdout", help="Output file path or stdout")
+def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_name: str, output: str) -> None:
     """List the contents of a Borg archive."""
-    orchestrator.list_archive_contents(repo_path, repo_name, archive_name)
+    orchestrator.list_archive_contents(repo_path, repo_name, archive_name, output)
 
 
 @cli.command()

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -39,7 +39,7 @@ def list_repos() -> None:
 
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
-@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=str)
 def list_archives(repo_path: str | None, repo_name: str | None) -> None:
     """List the archives in a Borg repository."""
     orchestrator.list_archives(repo_path, repo_name)
@@ -47,7 +47,7 @@ def list_archives(repo_path: str | None, repo_name: str | None) -> None:
 
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
-@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=str)
 @click.option("--archive-name", "-a", required=True, type=str)
 @click.option("--output", "-o", required=False, type=str, default="stdout", help="Output file path or stdout")
 def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_name: str, output: str) -> None:
@@ -57,7 +57,7 @@ def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_
 
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
-@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=str)
 def get_repo(repo_path: str | None, repo_name: str | None) -> None:
     """Get a Borg repository by name or path."""
     repo = orchestrator.lookup_repo(repo_path, repo_name)
@@ -82,7 +82,7 @@ def export_repo_key(repo_path: str) -> None:
 
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
-@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=str)
 @click.option("--pp", is_flag=True, show_default=True, default=True, help="Pretty print the repo info")
 def repo_info(repo_path: str | None, repo_name: str | None, pp: bool) -> None:
     """List a local Borg repository's info."""
@@ -111,7 +111,7 @@ def delete_archive(repo_path: str, archive_name: str, dry_run: bool) -> None:
 
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
-@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=str)
 @click.option("--dry-run", is_flag=True, show_default=True, default=False, help="Perform a dry run of the deletion")
 def delete_repo(repo_path: str | None, repo_name: str | None, dry_run: bool) -> None:
     """Delete a Borg repository."""
@@ -148,7 +148,7 @@ def modify_excludes(repo_name: str, delete_line_num: int) -> None:
 
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
-@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=str)
 @click.option("--dry-run", is_flag=True, show_default=True, default=False, help="Perform a dry run of the restore")
 @click.option("--force", is_flag=True, show_default=True, default=False, help="Force restore even if repo exists")
 def restore_repo(repo_path: str | None, repo_name: str | None, dry_run: bool, force: bool) -> None:

--- a/src/borgboi/cli.py
+++ b/src/borgboi/cli.py
@@ -48,6 +48,15 @@ def list_archives(repo_path: str | None, repo_name: str | None) -> None:
 @cli.command()
 @click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
 @click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
+@click.option("--archive-name", "-a", required=True, type=str)
+def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_name: str) -> None:
+    """List the contents of a Borg archive."""
+    orchestrator.list_archive_contents(repo_path, repo_name, archive_name)
+
+
+@cli.command()
+@click.option("--repo-path", "-r", required=False, type=click.Path(exists=False))
+@click.option("--repo-name", "-n", required=False, type=click.Path(exists=False))
 def get_repo(repo_path: str | None, repo_name: str | None) -> None:
     """Get a Borg repository by name or path."""
     repo = orchestrator.lookup_repo(repo_path, repo_name)

--- a/src/borgboi/lib/utils.py
+++ b/src/borgboi/lib/utils.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def shorten_archive_path(archive_path: str) -> str:
+    """
+    Shorten the archive path for display purposes.
+
+    Args:
+        archive_path (str): The full path of the archive.
+
+    Returns:
+        str: The shortened archive path.
+    """
+    home_dir = Path.home().as_posix()[1:]  # Get home directory without leading slash
+    if archive_path.startswith(home_dir):
+        archive_path = archive_path.replace(home_dir, "~", 1)
+    parts = archive_path.split("/")
+    if len(parts) > 3:
+        return "/".join(parts[:4] + ["..."] + parts[-2:])
+    return archive_path

--- a/src/borgboi/lib/utils.py
+++ b/src/borgboi/lib/utils.py
@@ -1,4 +1,4 @@
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -31,10 +31,8 @@ def calculate_archive_age(archive_time: str) -> str:
     Returns:
         str: A human-readable string representing the age of the archive (i.e. "2d 3h 15m").
     """
-    from datetime import datetime, timezone
-
     # Parse the custom format string and make it timezone-aware (UTC)
-    archive_datetime = datetime.strptime(archive_time, "%Y-%m-%d_%H:%M:%S").replace(tzinfo=timezone.utc)
+    archive_datetime = datetime.strptime(archive_time, "%Y-%m-%d_%H:%M:%S").replace(tzinfo=UTC)
     now = datetime.now(tz=UTC)
     age = now - archive_datetime
     days = age.days

--- a/src/borgboi/lib/utils.py
+++ b/src/borgboi/lib/utils.py
@@ -1,3 +1,4 @@
+from datetime import UTC
 from pathlib import Path
 
 
@@ -18,3 +19,33 @@ def shorten_archive_path(archive_path: str) -> str:
     if len(parts) > 3:
         return "/".join(parts[:4] + ["..."] + parts[-2:])
     return archive_path
+
+
+def calculate_archive_age(archive_time: str) -> str:
+    """
+    Calculate the age of a Borg archive based on its creation time.
+
+    Args:
+        archive_time (str): The creation time of the archive in "YYYY-MM-DD_HH:MM:SS" format (UTC).
+
+    Returns:
+        str: A human-readable string representing the age of the archive (i.e. "2d 3h 15m").
+    """
+    from datetime import datetime, timezone
+
+    # Parse the custom format string and make it timezone-aware (UTC)
+    archive_datetime = datetime.strptime(archive_time, "%Y-%m-%d_%H:%M:%S").replace(tzinfo=timezone.utc)
+    now = datetime.now(tz=UTC)
+    age = now - archive_datetime
+    days = age.days
+    hours, remainder = divmod(age.seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    if days > 0:
+        return f"{days}d {hours}h {minutes}m"
+    elif hours > 0:
+        return f"{hours}h {minutes}m"
+    elif minutes > 0:
+        return f"{minutes}m {seconds}s"
+    else:
+        return f"{seconds}s"

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -137,7 +137,7 @@ def list_archives(repo_path: str | None, repo_name: str | None) -> None:
     archives = borg.list_archives(repo.path)
     console.rule(f"[bold]Archives for {repo.name}[/]")
     for archive in archives:
-        console.print(f"↳ [bold {COLOR_HEX.sky}]{archive.name}[/]")
+        console.print(f"↳ [bold {COLOR_HEX.sky}]{archive.name}[/]\t[{COLOR_HEX.mauve}]ID={archive.id}[/]")
     console.rule()
 
 

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -144,7 +144,9 @@ def list_archives(repo_path: str | None, repo_name: str | None) -> None:
     console.rule()
 
 
-def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_name: str) -> None:
+def list_archive_contents(
+    repo_path: str | None, repo_name: str | None, archive_name: str, output_file: str = "stdout"
+) -> None:
     """
     Lists the contents of a specific Borg archive.
     """
@@ -152,9 +154,22 @@ def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_
     if not validator.repo_is_local(repo):
         raise ValueError("Repository must be local to list archive contents")
     contents = borg.list_archive_contents(repo.path, archive_name)
-    for item in contents:
-        console.print(f"↳ [bold {COLOR_HEX.sky}]{utils.shorten_archive_path(item.path)}[/]")
-    console.rule()
+
+    if output_file == "stdout":
+        output_lines = [f"↳ [bold {COLOR_HEX.sky}]{utils.shorten_archive_path(item.path)}[/]" for item in contents]
+    else:
+        output_lines = [f"{item.path}" for item in contents]  # Use original path for file output
+
+    if output_file == "stdout":
+        for line in output_lines:
+            console.print(line)
+        console.rule()
+    else:
+        output_path = Path(output_file)
+        with output_path.open("w") as f:
+            for line in output_lines:
+                _ = f.write(line + "\n")  # No prefix to remove
+        console.print(f"Archive contents written to [bold cyan]{output_path.as_posix()}[/]")
 
 
 def perform_daily_backup(repo_path: str) -> None:

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -6,6 +6,7 @@ from platform import system
 
 from borgboi import rich_utils, validator
 from borgboi.clients import borg, dynamodb, s3
+from borgboi.lib import utils
 from borgboi.lib.colors import COLOR_HEX
 from borgboi.models import BORGBOI_DIR_NAME, EXCLUDE_FILENAME, BorgBoiRepo
 from borgboi.rich_utils import console
@@ -148,9 +149,8 @@ def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_
     if not validator.repo_is_local(repo):
         raise ValueError("Repository must be local to list archive contents")
     contents = borg.list_archive_contents(repo.path, archive_name)
-    console.rule(f"[bold]Contents of {archive_name}[/]")
     for item in contents:
-        console.print(f"↳ [bold {COLOR_HEX.sky}]{item}[/]")
+        console.print(f"↳ [bold {COLOR_HEX.sky}]{utils.shorten_archive_path(item.path)}[/]")
     console.rule()
 
 

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -140,6 +140,20 @@ def list_archives(repo_path: str | None, repo_name: str | None) -> None:
     console.rule()
 
 
+def list_archive_contents(repo_path: str | None, repo_name: str | None, archive_name: str) -> None:
+    """
+    Lists the contents of a specific Borg archive.
+    """
+    repo = lookup_repo(repo_path, repo_name)
+    if not validator.repo_is_local(repo):
+        raise ValueError("Repository must be local to list archive contents")
+    contents = borg.list_archive_contents(repo.path, archive_name)
+    console.rule(f"[bold]Contents of {archive_name}[/]")
+    for item in contents:
+        console.print(f"↳ [bold {COLOR_HEX.sky}]{item}[/]")
+    console.rule()
+
+
 def perform_daily_backup(repo_path: str) -> None:
     repo = lookup_repo(repo_path, None)
     if validator.exclude_list_created(repo.name) is False:

--- a/src/borgboi/orchestrator.py
+++ b/src/borgboi/orchestrator.py
@@ -135,9 +135,12 @@ def list_archives(repo_path: str | None, repo_name: str | None) -> None:
     """
     repo = lookup_repo(repo_path, repo_name)
     archives = borg.list_archives(repo.path)
+    archives.sort(key=lambda x: x.name, reverse=True)
     console.rule(f"[bold]Archives for {repo.name}[/]")
     for archive in archives:
-        console.print(f"↳ [bold {COLOR_HEX.sky}]{archive.name}[/]\t[{COLOR_HEX.mauve}]ID={archive.id}[/]")
+        console.print(
+            f"↳ [bold {COLOR_HEX.sky}]{archive.name}[/]\t[bold {COLOR_HEX.green}]Age: {utils.calculate_archive_age(archive.name)}[/]\t[{COLOR_HEX.mauve}]ID: {archive.id}[/]"
+        )
     console.rule()
 
 


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `borgboi` project, including a GitHub Actions workflow for secret scanning, a new command for listing archive contents, and utility functions for improving archive-related operations. Below is a summary of the most important changes:

### GitHub Actions Integration:
* Added a new `gitleaks` workflow to scan for secrets in the codebase during pull requests, pushes, and manual workflow dispatches. This ensures that sensitive information is not inadvertently committed. (`.github/workflows/gitleaks.yml`)

### New Command for Archive Management:
* Introduced the `list_archive_contents` CLI command to list the contents of a specific Borg archive. This command accepts repository path, repository name, and archive name as parameters. (`src/borgboi/cli.py`)

### Borg Archive Enhancements:
* Added the `list_archive_contents` function in `borg.py` to retrieve and parse the contents of a Borg archive using the `--json-lines` flag. This function returns a list of `ArchivedFile` objects, which represent individual files in the archive. (`src/borgboi/clients/borg.py`)
* Updated the `list_archives` function in `orchestrator.py` to sort archives by name in reverse order and display additional details such as archive age and ID. (`src/borgboi/orchestrator.py`)

### Utility Functions:
* Added two utility functions in `utils.py`:
  - `shorten_archive_path`: Shortens long archive paths for better display.
  - [`calculate_archive_age`](diffhunk://#diff-cadf24ace382d112ab3a8d3b8e1fefb7f429dd8bef323d3ce773e44c039fbf94R1-R51): Calculates the age of an archive in a human-readable format (e.g., "2d 3h 15m"). (`src/borgboi/lib/utils.py`)

These changes improve the functionality, usability, and security of the `borgboi` project.