### PR TITLE
Cleanup Security Dirs Created from Tests

### DIFF
--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -31,7 +31,7 @@ class BorgBoiRepo(BaseModel):
             raise ValueError(f"os_platform must be either 'Linux' or 'Darwin'. '{v}' is not supported.")
         return v
 
-    @computed_field  # mypy: ignore[prop-decorator]
+    @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def safe_path(self) -> str:
         """


### PR DESCRIPTION
This pull request introduces changes to improve test cleanup, update type annotations, and enhance code clarity. The most significant updates include the addition of a helper function for cleaning up test repository security files, modifications to test fixtures to ensure proper cleanup, and a minor adjustment to a type annotation for consistency.

### Test cleanup improvements:
* Added `_cleanup_borg_security_files` helper function in `tests/conftest.py` to remove security files associated with test repositories and handle potential cleanup failures gracefully.
* Updated `borg_repo` and `borg_repo_without_excludes` test fixtures in `tests/conftest.py` to use the `_cleanup_borg_security_files` function, ensuring security files are cleaned up after tests run.

### Type annotation updates:
* Replaced `mypy: ignore[prop-decorator]` with `type: ignore[prop-decorator]` in the `@computed_field` decorator of the `safe_path` property in `src/borgboi/models.py` for consistency with type-checking tools.

### Miscellaneous:
* Added `warnings` import to `tests/conftest.py` to support warning messages in the new cleanup function.