### PR TITLE
fix(tui): Refresh Dashboard after Successful Backup

### DIFF
--- a/src/borgboi/tui/app.py
+++ b/src/borgboi/tui/app.py
@@ -163,6 +163,10 @@ class BorgBoiApp(App[None]):
         """Reload the repos table and sparkline from storage."""
         if self.screen is not self._main_screen:
             return
+        self._refresh_dashboard()
+
+    def _refresh_dashboard(self) -> None:
+        """Reload the dashboard data shown on the main screen."""
         if self._repos_table is None:
             return
         self._repos_table.loading = True
@@ -179,4 +183,9 @@ class BorgBoiApp(App[None]):
         """Push the daily backup screen."""
         if self.screen is not self._main_screen:
             return
-        _ = self.push_screen(DailyBackupScreen(orchestrator=self.orchestrator))
+        _ = self.push_screen(
+            DailyBackupScreen(
+                orchestrator=self.orchestrator,
+                on_back_after_success=self._refresh_dashboard,
+            )
+        )

--- a/src/borgboi/tui/daily_backup_screen.py
+++ b/src/borgboi/tui/daily_backup_screen.py
@@ -500,11 +500,14 @@ class DailyBackupScreen(Screen[None]):
     def __init__(
         self,
         orchestrator: Orchestrator,
+        on_back_after_success: Callable[[], None] | None = None,
     ) -> None:
         super().__init__()
         self._orchestrator = orchestrator
+        self._on_back_after_success = on_back_after_success
         self._repos: list[BorgBoiRepo] = []
         self._backup_running = False
+        self._backup_completed = False
 
     @property
     def _is_offline(self) -> bool:
@@ -658,6 +661,7 @@ class DailyBackupScreen(Screen[None]):
         self.app.call_from_thread(self._on_backup_complete)
 
     def _on_backup_complete(self) -> None:
+        self._backup_completed = True
         self._backup_running = False
         self._set_controls_enabled(True)
         self.query_one("#daily-backup-clear", Button).disabled = False
@@ -677,3 +681,5 @@ class DailyBackupScreen(Screen[None]):
     def action_back(self) -> None:
         """Pop this screen and return to the previous screen."""
         _ = self.app.pop_screen()
+        if self._backup_completed and self._on_back_after_success is not None:
+            self._on_back_after_success()

--- a/tests/tui/app_test.py
+++ b/tests/tui/app_test.py
@@ -74,6 +74,50 @@ async def test_action_daily_backup_pushes_screen(tui_config: Config) -> None:
         assert isinstance(app.screen, DailyBackupScreen)
 
 
+async def test_returning_from_successful_backup_refreshes_dashboard(tui_config: Config, monkeypatch: Any) -> None:
+    orchestrator = cast(
+        Any,
+        SimpleNamespace(
+            config=tui_config,
+            borg=None,
+            storage=None,
+            s3=None,
+            list_repos=lambda: [build_repo("alpha")],
+        ),
+    )
+    app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
+
+    repo_refreshes = 0
+    sparkline_refreshes = 0
+
+    def fake_load_repos() -> None:
+        nonlocal repo_refreshes
+        repo_refreshes += 1
+
+    def fake_load_sparkline_data() -> None:
+        nonlocal sparkline_refreshes
+        sparkline_refreshes += 1
+
+    monkeypatch.setattr(app, "_load_repos", fake_load_repos)
+    monkeypatch.setattr(app, "_load_sparkline_data", fake_load_sparkline_data)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        initial_repo_refreshes = repo_refreshes
+        initial_sparkline_refreshes = sparkline_refreshes
+
+        await pilot.press("b")
+        await pilot.pause()
+        assert isinstance(app.screen, DailyBackupScreen)
+
+        app.screen._on_backup_complete()
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert repo_refreshes == initial_repo_refreshes + 1
+        assert sparkline_refreshes == initial_sparkline_refreshes + 1
+
+
 async def test_action_daily_backup_ignored_on_non_main_screen(tui_app: BorgBoiApp) -> None:
     async with tui_app.run_test() as pilot:
         await pilot.press("e")  # push excludes screen


### PR DESCRIPTION
Reload the home dashboard when the daily backup screen closes after a successful run so new archives appear immediately in the sparkline and repo list.

Closes #221 