### PR TITLE
chore(deps): Require Minimum Release Age of 24 hours

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
 docs = ["zensical>=0.0.24"]
 
 [tool.uv]
+exclude-newer = "24 hours"
 default-groups = ["dev", "docs"]
 
 [tool.pytest.ini_options]

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
   "reviewers": [
     "fullerzz"
   ],
+  "minimumReleaseAge": "1 day",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "prCreation": "not-pending",
+  "rebaseWhen": "behind-base-branch",
+  "pruneStaleBranches": true,
   "packageRules": [
     {
       "matchManagers": [

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "2026-03-30T22:38:49.147867Z"
+exclude-newer-span = "PT24H"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
This PR updates the renovate config to require dependencies are at least 24 hours old before renovate will open a PR.

Additionally, this PR updates the `uv` config to exclude packages newer than 24 hours.

Related docs:

- https://docs.renovatebot.com/key-concepts/minimum-release-age/
- https://docs.astral.sh/uv/reference/settings/#exclude-newer