### PR TITLE
feat(tui): Add TUI Screen for Comparing Archive Contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ output.txt
 .claude/settings.local.json
 borgopher/
 .claude
+.opencode

--- a/src/borgboi/cli/backup.py
+++ b/src/borgboi/cli/backup.py
@@ -9,12 +9,13 @@ from cyclopts import App, Parameter
 
 from borgboi.cli.main import ContextArg, confirm_action, print_error_and_exit
 from borgboi.core.logging import get_logger
+from borgboi.lib.diff import format_diff_change, summarize_diff_changes
 from borgboi.rich_utils import console
 
 if TYPE_CHECKING:
     from rich.table import Table
 
-    from borgboi.clients.borg import ArchiveInfo, DiffChange, DiffResult
+    from borgboi.clients.borg import ArchiveInfo, DiffResult
 
 
 logger = get_logger(__name__)
@@ -77,61 +78,6 @@ def _render_archive_stats_table(repo_path: str, archive_info: ArchiveInfo) -> No
     console.print(size_table)
 
 
-def _summarize_diff_changes(result: DiffResult) -> dict[str, int]:
-    summary = {
-        "added": 0,
-        "removed": 0,
-        "modified": 0,
-        "mode": 0,
-        "bytes_added": 0,
-        "bytes_removed": 0,
-    }
-
-    for entry in result.entries:
-        entry_categories = {change.type for change in entry.changes}
-        if "added" in entry_categories:
-            summary["added"] += 1
-        if "removed" in entry_categories:
-            summary["removed"] += 1
-        if "modified" in entry_categories:
-            summary["modified"] += 1
-        if "mode" in entry_categories:
-            summary["mode"] += 1
-
-        for change in entry.changes:
-            added_bytes = change.added or 0
-            removed_bytes = change.removed or 0
-            if change.type == "added":
-                summary["bytes_added"] += added_bytes or change.size or 0
-            elif change.type == "removed":
-                summary["bytes_removed"] += removed_bytes or change.size or 0
-            elif change.type == "modified":
-                summary["bytes_added"] += added_bytes
-                summary["bytes_removed"] += removed_bytes
-
-    return summary
-
-
-def _format_diff_change(change: DiffChange) -> str:
-    from borgboi.lib import utils
-
-    match change.type:
-        case "added":
-            return f"added ({utils.format_size_bytes(change.added or change.size or 0)})"
-        case "removed":
-            return f"removed ({utils.format_size_bytes(change.removed or change.size or 0)})"
-        case "modified":
-            added = utils.format_size_bytes(change.added or 0)
-            removed = utils.format_size_bytes(change.removed or 0)
-            return f"modified (+{added}, -{removed})"
-        case "mode":
-            return f"mode {change.old_mode or '?'} -> {change.new_mode or '?'}"
-        case _ if change.old is not None or change.new is not None:
-            return f"{change.type} {change.old if change.old is not None else '?'} -> {change.new if change.new is not None else '?'}"
-        case _:
-            return change.type
-
-
 def _render_diff_result(result: DiffResult, *, json_output: bool) -> None:
     from borgboi.lib import utils
 
@@ -149,11 +95,11 @@ def _render_diff_result(result: DiffResult, *, json_output: bool) -> None:
         return
 
     for entry in result.entries:
-        changes = ", ".join(_format_diff_change(change) for change in entry.changes)
+        changes = ", ".join(format_diff_change(change) for change in entry.changes)
         console.print(f"[bold]{entry.path}[/]")
         console.print(f"  {changes}")
 
-    summary = _summarize_diff_changes(result)
+    summary = summarize_diff_changes(result)
     console.rule("[bold]Summary[/]")
     console.print(f"Changed paths: {len(result.entries)}")
     console.print(f"Added: {summary['added']}")

--- a/src/borgboi/lib/diff.py
+++ b/src/borgboi/lib/diff.py
@@ -1,0 +1,61 @@
+"""Shared helpers for formatting and summarising archive diff results."""
+
+from __future__ import annotations
+
+from borgboi.clients.borg import DiffChange, DiffResult
+from borgboi.lib.utils import format_size_bytes
+
+
+def summarize_diff_changes(result: DiffResult) -> dict[str, int]:
+    """Summarize archive diff changes into category counts and byte totals."""
+    summary = {
+        "added": 0,
+        "removed": 0,
+        "modified": 0,
+        "mode": 0,
+        "bytes_added": 0,
+        "bytes_removed": 0,
+    }
+
+    for entry in result.entries:
+        entry_categories = {change.type for change in entry.changes}
+        if "added" in entry_categories:
+            summary["added"] += 1
+        if "removed" in entry_categories:
+            summary["removed"] += 1
+        if "modified" in entry_categories:
+            summary["modified"] += 1
+        if "mode" in entry_categories:
+            summary["mode"] += 1
+
+        for change in entry.changes:
+            added_bytes = change.added or 0
+            removed_bytes = change.removed or 0
+            if change.type == "added":
+                summary["bytes_added"] += added_bytes or change.size or 0
+            elif change.type == "removed":
+                summary["bytes_removed"] += removed_bytes or change.size or 0
+            elif change.type == "modified":
+                summary["bytes_added"] += added_bytes
+                summary["bytes_removed"] += removed_bytes
+
+    return summary
+
+
+def format_diff_change(change: DiffChange) -> str:
+    """Render a single diff change into compact human-readable text."""
+    match change.type:
+        case "added":
+            return f"added ({format_size_bytes(change.added or change.size or 0)})"
+        case "removed":
+            return f"removed ({format_size_bytes(change.removed or change.size or 0)})"
+        case "modified":
+            added = format_size_bytes(change.added or 0)
+            removed = format_size_bytes(change.removed or 0)
+            return f"modified (+{added}, -{removed})"
+        case "mode":
+            return f"mode {change.old_mode or '?'} -> {change.new_mode or '?'}"
+        case _ if change.old is not None or change.new is not None:
+            return f"{change.type} {change.old if change.old is not None else '?'} -> {change.new if change.new is not None else '?'}"
+        case _:
+            return change.type

--- a/src/borgboi/lib/diff.py
+++ b/src/borgboi/lib/diff.py
@@ -29,12 +29,12 @@ def summarize_diff_changes(result: DiffResult) -> dict[str, int]:
             summary["mode"] += 1
 
         for change in entry.changes:
-            added_bytes = change.added or 0
-            removed_bytes = change.removed or 0
+            added_bytes = change.added if change.added is not None else 0
+            removed_bytes = change.removed if change.removed is not None else 0
             if change.type == "added":
-                summary["bytes_added"] += added_bytes or change.size or 0
+                summary["bytes_added"] += added_bytes if change.added is not None else (change.size or 0)
             elif change.type == "removed":
-                summary["bytes_removed"] += removed_bytes or change.size or 0
+                summary["bytes_removed"] += removed_bytes if change.removed is not None else (change.size or 0)
             elif change.type == "modified":
                 summary["bytes_added"] += added_bytes
                 summary["bytes_removed"] += removed_bytes
@@ -46,12 +46,14 @@ def format_diff_change(change: DiffChange) -> str:
     """Render a single diff change into compact human-readable text."""
     match change.type:
         case "added":
-            return f"added ({format_size_bytes(change.added or change.size or 0)})"
+            size = change.added if change.added is not None else (change.size or 0)
+            return f"added ({format_size_bytes(size)})"
         case "removed":
-            return f"removed ({format_size_bytes(change.removed or change.size or 0)})"
+            size = change.removed if change.removed is not None else (change.size or 0)
+            return f"removed ({format_size_bytes(size)})"
         case "modified":
-            added = format_size_bytes(change.added or 0)
-            removed = format_size_bytes(change.removed or 0)
+            added = format_size_bytes(change.added if change.added is not None else 0)
+            removed = format_size_bytes(change.removed if change.removed is not None else 0)
             return f"modified (+{added}, -{removed})"
         case "mode":
             return f"mode {change.old_mode or '?'} -> {change.new_mode or '?'}"

--- a/src/borgboi/tui/archive_compare_screen.py
+++ b/src/borgboi/tui/archive_compare_screen.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import shutil
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -14,6 +13,8 @@ from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, Vertical
+from textual.message import Message
+from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import Button, DirectoryTree, Footer, Header, Label, Select, Static, Switch, Tree
 from textual.widgets.directory_tree import DirEntry
@@ -72,46 +73,54 @@ def _archive_sort_key(archive: RepoArchive) -> tuple[str, str]:
 
 
 class CompareDirectoryTree(DirectoryTree):
-    """Directory tree that reports directory expand/collapse changes to the screen."""
+    """Directory tree with compare-specific helpers and sync messages."""
+
+    class DirectoryExpanded(Message):
+        """Posted when a directory node is expanded."""
+
+        def __init__(self, directory_tree: CompareDirectoryTree, path: Path) -> None:
+            self.directory_tree = directory_tree
+            self.path = path
+            super().__init__()
+
+    class DirectoryCollapsed(Message):
+        """Posted when a directory node is collapsed."""
+
+        def __init__(self, directory_tree: CompareDirectoryTree, path: Path) -> None:
+            self.directory_tree = directory_tree
+            self.path = path
+            super().__init__()
 
     def __init__(
         self,
         path: str | Path,
         *,
-        on_directory_expanded: Callable[[CompareDirectoryTree, Path], Awaitable[None]] | None = None,
-        on_directory_collapsed: Callable[[CompareDirectoryTree, Path], Awaitable[None]] | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
         disabled: bool = False,
     ) -> None:
-        self._on_directory_expanded = on_directory_expanded
-        self._on_directory_collapsed = on_directory_collapsed
         super().__init__(path, name=name, id=id, classes=classes, disabled=disabled)
 
-    @override
-    async def _on_tree_node_expanded(self, event: Tree.NodeExpanded[DirEntry]) -> None:
-        """Emit a screen-friendly message after Textual finishes loading a directory."""
-        await super()._on_tree_node_expanded(event)
+    def on_tree_node_expanded(self, event: Tree.NodeExpanded[DirEntry]) -> None:
+        """Relay directory expansion through a public custom message."""
         dir_entry = event.node.data
         if dir_entry is None or not event.node.allow_expand:
             return
-        if self._on_directory_expanded is not None:
-            await self._on_directory_expanded(self, dir_entry.path)
+        self.post_message(self.DirectoryExpanded(self, dir_entry.path))
 
-    async def _on_tree_node_collapsed(self, event: Tree.NodeCollapsed[DirEntry]) -> None:
-        """Emit a screen-friendly message after a directory node is collapsed."""
+    def on_tree_node_collapsed(self, event: Tree.NodeCollapsed[DirEntry]) -> None:
+        """Relay directory collapse through a public custom message."""
         dir_entry = event.node.data
         if dir_entry is None or not event.node.allow_expand:
             return
-        if self._on_directory_collapsed is not None:
-            await self._on_directory_collapsed(self, dir_entry.path)
+        self.post_message(self.DirectoryCollapsed(self, dir_entry.path))
 
     async def ensure_node_loaded(self, node: TreeNode[DirEntry]) -> None:
-        """Ensure a directory node's children are loaded into memory."""
+        """Ensure a directory node's children are loaded using public APIs."""
         if not node.allow_expand or node.data is None or node.data.loaded:
             return
-        await self._add_to_load_queue(node)
+        await self.reload_node(node)
 
     async def find_node_by_relative_path(self, relative_path: Path) -> TreeNode[DirEntry] | None:
         """Locate a node by relative path, loading ancestor directories as needed."""
@@ -134,6 +143,8 @@ class CompareDirectoryTree(DirectoryTree):
 
 class ArchiveCompareScreen(Screen[None]):
     """Screen for visually comparing two archives from the same repository."""
+
+    expanded_paths: reactive[frozenset[str]] = reactive(frozenset(), init=False)
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "back", "Back"),
@@ -163,7 +174,6 @@ class ArchiveCompareScreen(Screen[None]):
         self._newer_root = self._compare_temp_root / "newer"
         self._older_root_resolved = self._older_root.resolve()
         self._newer_root_resolved = self._newer_root.resolve()
-        self._mirrored_tree_operations: set[tuple[str, str, str]] = set()
         self._older_root.mkdir(parents=True, exist_ok=True)
         self._newer_root.mkdir(parents=True, exist_ok=True)
         super().__init__(**kwargs)
@@ -182,8 +192,6 @@ class ArchiveCompareScreen(Screen[None]):
                     yield CompareDirectoryTree(
                         self._older_root,
                         id="archive-compare-older-tree",
-                        on_directory_expanded=self._mirror_directory_expansion,
-                        on_directory_collapsed=self._mirror_directory_collapse,
                     )
                 with Vertical(id="archive-compare-details", classes="archive-compare-pane"):
                     with Horizontal(id="archive-compare-center-controls"):
@@ -198,8 +206,6 @@ class ArchiveCompareScreen(Screen[None]):
                     yield CompareDirectoryTree(
                         self._newer_root,
                         id="archive-compare-newer-tree",
-                        on_directory_expanded=self._mirror_directory_expansion,
-                        on_directory_collapsed=self._mirror_directory_collapse,
                     )
         yield Footer()
 
@@ -372,7 +378,7 @@ class ArchiveCompareScreen(Screen[None]):
         )
         self.query_one("#archive-compare-older-heading", Static).update(self._render_archive_heading(result.archive1))
         self.query_one("#archive-compare-newer-heading", Static).update(self._render_archive_heading(result.archive2))
-        self._mirrored_tree_operations.clear()
+        self.expanded_paths = frozenset()
 
         _ = self._older_tree.reload()
         _ = self._newer_tree.reload()
@@ -408,48 +414,65 @@ class ArchiveCompareScreen(Screen[None]):
         """Update the detail panel when a directory is selected in either tree."""
         self._show_selected_path(event.path)
 
-    async def _mirror_directory_expansion(self, source_tree: CompareDirectoryTree, expanded_path: Path) -> None:
-        """Mirror user-driven directory expansions into the opposite archive tree."""
-        await self._sync_directory_state(source_tree, expanded_path, operation="expand")
+    def on_compare_directory_tree_directory_expanded(self, event: CompareDirectoryTree.DirectoryExpanded) -> None:
+        """Record expanded directories so both trees converge on the same state."""
+        self._update_expanded_path(event.path, expanded=True)
 
-    async def _mirror_directory_collapse(self, source_tree: CompareDirectoryTree, collapsed_path: Path) -> None:
-        """Mirror user-driven directory collapses into the opposite archive tree."""
-        await self._sync_directory_state(source_tree, collapsed_path, operation="collapse")
+    def on_compare_directory_tree_directory_collapsed(self, event: CompareDirectoryTree.DirectoryCollapsed) -> None:
+        """Record collapsed directories so both trees converge on the same state."""
+        self._update_expanded_path(event.path, expanded=False)
 
-    async def _sync_directory_state(
-        self, source_tree: CompareDirectoryTree, directory_path: Path, *, operation: Literal["expand", "collapse"]
-    ) -> None:
-        """Synchronize a directory expand/collapse operation into the opposite tree."""
+    def _update_expanded_path(self, directory_path: Path, *, expanded: bool) -> None:
+        """Update the shared expansion state from a tree event."""
         relative_path = self._relative_compare_path(directory_path)
         if relative_path is None or not relative_path.parts:
             return
 
-        message_key = (operation, source_tree.id or "", relative_path.as_posix())
-        if message_key in self._mirrored_tree_operations:
-            self._mirrored_tree_operations.remove(message_key)
+        relative_path_str = relative_path.as_posix()
+        if expanded:
+            self.expanded_paths = frozenset((*self.expanded_paths, relative_path_str))
             return
 
-        peer_tree = self._get_peer_tree(source_tree)
-        if peer_tree is None:
-            return
+        self.expanded_paths = frozenset(path for path in self.expanded_paths if path != relative_path_str)
 
-        matching_node = await peer_tree.find_node_by_relative_path(relative_path)
-        if matching_node is None or not matching_node.allow_expand:
+    def watch_expanded_paths(self, old_paths: frozenset[str], new_paths: frozenset[str]) -> None:
+        """Apply expansion-state changes to both compare trees."""
+        if not hasattr(self, "_older_tree"):
+            return
+        self._sync_expanded_paths(old_paths, new_paths)
+
+    @work(exclusive=True, group="archive-compare-tree-sync")
+    async def _sync_expanded_paths(self, old_paths: frozenset[str], new_paths: frozenset[str]) -> None:
+        """Synchronize both directory trees to the shared expansion state."""
+        paths_to_expand = sorted(new_paths - old_paths, key=lambda item: (len(Path(item).parts), item))
+        paths_to_collapse = sorted(old_paths - new_paths, key=lambda item: (len(Path(item).parts), item), reverse=True)
+
+        for tree in (self._older_tree, self._newer_tree):
+            for relative_path in paths_to_expand:
+                await self._set_tree_path_state(tree, Path(relative_path), operation="expand")
+            for relative_path in paths_to_collapse:
+                await self._set_tree_path_state(tree, Path(relative_path), operation="collapse")
+
+    async def _set_tree_path_state(
+        self, tree: CompareDirectoryTree, relative_path: Path, *, operation: Literal["expand", "collapse"]
+    ) -> None:
+        """Apply an expansion-state operation to one tree if the path exists there."""
+        target_node = await tree.find_node_by_relative_path(relative_path)
+        if target_node is None or not target_node.allow_expand:
             return
 
         if operation == "expand":
-            if matching_node.is_expanded:
-                return
-            self._mirrored_tree_operations.add((operation, peer_tree.id or "", relative_path.as_posix()))
-            matching_node.expand()
-            await peer_tree.ensure_node_loaded(matching_node)
+            for part_count in range(1, len(relative_path.parts) + 1):
+                node = await tree.find_node_by_relative_path(Path(*relative_path.parts[:part_count]))
+                if node is None or not node.allow_expand:
+                    return
+                if node.is_collapsed:
+                    node.expand()
+                await tree.ensure_node_loaded(node)
             return
 
-        if operation == "collapse":
-            if matching_node.is_collapsed:
-                return
-            self._mirrored_tree_operations.add((operation, peer_tree.id or "", relative_path.as_posix()))
-            matching_node.collapse()
+        if target_node.is_expanded:
+            target_node.collapse()
 
     def _show_selected_path(self, selected_path: Path) -> None:
         """Render details for the selected compare path or directory."""
@@ -492,14 +515,6 @@ class ArchiveCompareScreen(Screen[None]):
                 return resolved_path.relative_to(root)
             except ValueError:
                 continue
-        return None
-
-    def _get_peer_tree(self, source_tree: CompareDirectoryTree) -> CompareDirectoryTree | None:
-        """Return the opposite compare tree for a given source tree."""
-        if source_tree is self._older_tree:
-            return self._newer_tree
-        if source_tree is self._newer_tree:
-            return self._older_tree
         return None
 
     def _render_archive_heading(self, archive_name: str) -> str:

--- a/src/borgboi/tui/archive_compare_screen.py
+++ b/src/borgboi/tui/archive_compare_screen.py
@@ -1,0 +1,409 @@
+"""Archive comparison screen for the BorgBoi TUI."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any, ClassVar, override
+
+from rich.markup import escape
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import Button, DirectoryTree, Footer, Header, Label, Select, Static, Switch
+
+from borgboi.clients.borg import DiffChange, DiffResult, RepoArchive
+from borgboi.core.logging import get_logger
+from borgboi.core.models import DiffOptions
+from borgboi.lib.diff import format_diff_change, summarize_diff_changes
+from borgboi.lib.utils import format_iso_timestamp, format_size_bytes
+
+logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from borgboi.core.orchestrator import Orchestrator
+    from borgboi.models import BorgBoiRepo
+
+
+@dataclass(frozen=True)
+class ComparePathState:
+    """Comparison metadata for a single changed archive path."""
+
+    relative_path: Path
+    older_exists: bool
+    newer_exists: bool
+    changes: tuple[DiffChange, ...]
+
+
+def build_compare_path_states(result: DiffResult) -> dict[Path, ComparePathState]:
+    """Build a lookup of changed paths and which side each path exists on."""
+    states: dict[Path, ComparePathState] = {}
+    for entry in result.entries:
+        older_exists, newer_exists = _resolve_path_presence(entry.changes)
+        states[entry.path] = ComparePathState(
+            relative_path=entry.path,
+            older_exists=older_exists,
+            newer_exists=newer_exists,
+            changes=tuple(entry.changes),
+        )
+    return states
+
+
+def _resolve_path_presence(changes: list[DiffChange]) -> tuple[bool, bool]:
+    """Infer whether a changed path exists in the older and newer archive."""
+    change_types = {change.type for change in changes}
+    if change_types == {"added"}:
+        return False, True
+    if change_types == {"removed"}:
+        return True, False
+    return True, True
+
+
+def _archive_sort_key(archive: RepoArchive) -> tuple[str, str]:
+    """Sort archives newest-first using the timestamp when available."""
+    return (archive.time or archive.start or "", archive.name)
+
+
+class ArchiveCompareScreen(Screen[None]):
+    """Screen for visually comparing two archives from the same repository."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "back", "Back"),
+        Binding("r", "run_compare", "Compare"),
+    ]
+
+    def __init__(
+        self,
+        repo: BorgBoiRepo,
+        orchestrator: Orchestrator,
+        *,
+        initial_older_archive: str | None = None,
+        initial_newer_archive: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._repo = repo
+        self._orchestrator = orchestrator
+        self._initial_older_archive = initial_older_archive
+        self._initial_newer_archive = initial_newer_archive
+        self._archives: list[RepoArchive] = []
+        self._archive_index: dict[str, RepoArchive] = {}
+        self._path_states: dict[Path, ComparePathState] = {}
+        self._compare_result = DiffResult(archive1="", archive2="", entries=[])
+        self._tempdir = TemporaryDirectory(prefix="borgboi-archive-compare-")
+        self._compare_temp_root = Path(self._tempdir.name)
+        self._older_root = self._compare_temp_root / "older"
+        self._newer_root = self._compare_temp_root / "newer"
+        self._older_root.mkdir(parents=True, exist_ok=True)
+        self._newer_root.mkdir(parents=True, exist_ok=True)
+        super().__init__(**kwargs)
+
+    @override
+    def compose(self) -> ComposeResult:
+        """Build the archive comparison layout."""
+        yield Header()
+        with Vertical(id="archive-compare-screen"):
+            yield Static(f"Archive Compare: {self._repo.name}", id="archive-compare-title")
+            yield Label("Loading archive choices...", id="archive-compare-status")
+            with Horizontal(id="archive-compare-body"):
+                with Vertical(classes="archive-compare-pane"):
+                    yield Select[str]([], prompt="Older archive", id="archive-compare-older-select", disabled=True)
+                    yield Static("Older archive", id="archive-compare-older-heading", markup=True)
+                    yield DirectoryTree(self._older_root, id="archive-compare-older-tree")
+                with Vertical(id="archive-compare-details", classes="archive-compare-pane"):
+                    with Horizontal(id="archive-compare-center-controls"):
+                        yield Label("Content only", id="archive-compare-content-only-label")
+                        yield Switch(value=False, id="archive-compare-content-only-switch")
+                        yield Button("Compare", id="archive-compare-run-btn", variant="primary", disabled=True)
+                    yield Static("Loading comparison summary...", id="archive-compare-summary", markup=True)
+                    yield Static("No path selected.", id="archive-compare-selection", markup=True)
+                with Vertical(classes="archive-compare-pane"):
+                    yield Select[str]([], prompt="Newer archive", id="archive-compare-newer-select", disabled=True)
+                    yield Static("Newer archive", id="archive-compare-newer-heading", markup=True)
+                    yield DirectoryTree(self._newer_root, id="archive-compare-newer-tree")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Prepare the trees and start loading archive choices."""
+        for tree_id in ("#archive-compare-older-tree", "#archive-compare-newer-tree"):
+            tree = self.query_one(tree_id, DirectoryTree)
+            tree.show_root = False
+            tree.root.expand()
+
+        self.query_one("#archive-compare-older-select", Select).loading = True
+        self.query_one("#archive-compare-newer-select", Select).loading = True
+        self._load_archive_choices()
+
+    def on_unmount(self) -> None:
+        """Clean up any temporary mirror directories created for comparison."""
+        self._cleanup_tempdir()
+
+    def action_back(self) -> None:
+        """Return to the previous screen."""
+        _ = self.app.pop_screen()
+
+    def action_run_compare(self) -> None:
+        """Run the comparison for the selected archive pair."""
+        self._start_compare()
+
+    @work(thread=True, exclusive=True, group="archive-choices")
+    def _load_archive_choices(self) -> None:
+        """Load archive options and determine the default compare pair."""
+        try:
+            archives = sorted(self._orchestrator.list_archives(self._repo), key=_archive_sort_key, reverse=True)
+            older_archive = self._initial_older_archive
+            newer_archive = self._initial_newer_archive
+            if older_archive is None or newer_archive is None:
+                older, newer = self._orchestrator.get_two_most_recent_archives(self._repo)
+                older_archive = older.name
+                newer_archive = newer.name
+        except Exception as exc:
+            logger.exception("Failed to load archive choices", repo_name=self._repo.name, error=str(exc))
+            self.app.call_from_thread(self._on_archive_choices_error, exc)
+            return
+
+        assert older_archive is not None
+        assert newer_archive is not None
+        self.app.call_from_thread(self._apply_archive_choices, archives, older_archive, newer_archive)
+
+    def _apply_archive_choices(self, archives: list[RepoArchive], older_archive: str, newer_archive: str) -> None:
+        """Populate the archive selectors and kick off the initial compare."""
+        self._archives = archives
+        self._archive_index = {archive.name: archive for archive in archives}
+
+        older_select = self.query_one("#archive-compare-older-select", Select)
+        newer_select = self.query_one("#archive-compare-newer-select", Select)
+
+        options = [(archive.name, archive.name) for archive in archives]
+        older_select.set_options(options)
+        newer_select.set_options(options)
+        older_select.loading = False
+        newer_select.loading = False
+        older_select.disabled = False
+        newer_select.disabled = False
+        self.query_one("#archive-compare-run-btn", Button).disabled = False
+
+        older_select.value = older_archive
+        newer_select.value = newer_archive
+        self.query_one("#archive-compare-status", Label).update("Archive choices loaded. Running initial comparison...")
+        self._start_compare()
+
+    def _on_archive_choices_error(self, error: Exception) -> None:
+        """Handle archive-choice loading failures."""
+        self.query_one("#archive-compare-older-select", Select).loading = False
+        self.query_one("#archive-compare-newer-select", Select).loading = False
+        self.query_one("#archive-compare-status", Label).update(f"Failed to load archive choices: {error}")
+        self.query_one("#archive-compare-summary", Static).update(
+            f"[#f38ba8]Archive comparison unavailable:[/] {escape(str(error))}"
+        )
+        self.notify(str(error), severity="error", title="Archive Compare")
+
+    def _start_compare(self) -> None:
+        """Validate the selected archive pair and start a background compare."""
+        older_select = self.query_one("#archive-compare-older-select", Select)
+        newer_select = self.query_one("#archive-compare-newer-select", Select)
+
+        if older_select.value is Select.BLANK or newer_select.value is Select.BLANK:
+            return
+
+        older_archive = str(older_select.value)
+        newer_archive = str(newer_select.value)
+        if older_archive == newer_archive:
+            self.notify("Select two different archives to compare.", severity="warning", title="Archive Compare")
+            return
+
+        self._set_compare_controls_enabled(False)
+        self.query_one("#archive-compare-status", Label).update(f"Comparing {older_archive} -> {newer_archive}...")
+        self.query_one("#archive-compare-selection", Static).update("No path selected.")
+        self._compare_archives(
+            older_archive, newer_archive, self.query_one("#archive-compare-content-only-switch", Switch).value
+        )
+
+    @work(thread=True, exclusive=True, group="archive-compare")
+    def _compare_archives(self, older_archive: str, newer_archive: str, content_only: bool) -> None:
+        """Run the archive diff and materialize the temporary mirror trees."""
+        try:
+            result = self._orchestrator.diff_archives(
+                self._repo,
+                older_archive,
+                newer_archive,
+                options=DiffOptions(content_only=content_only),
+            )
+            path_states = build_compare_path_states(result)
+            self._reset_compare_roots()
+            self._materialize_compare_root(
+                self._older_root,
+                [state.relative_path for state in path_states.values() if state.older_exists],
+            )
+            self._materialize_compare_root(
+                self._newer_root,
+                [state.relative_path for state in path_states.values() if state.newer_exists],
+            )
+        except Exception as exc:
+            logger.exception(
+                "Failed to compare archives",
+                repo_name=self._repo.name,
+                older_archive=older_archive,
+                newer_archive=newer_archive,
+                error=str(exc),
+            )
+            self.app.call_from_thread(self._on_compare_error, exc)
+            return
+
+        self.app.call_from_thread(self._apply_compare_result, result, path_states, content_only)
+
+    def _reset_compare_roots(self) -> None:
+        """Clear any previous synthetic compare tree contents."""
+        for root in (self._older_root, self._newer_root):
+            shutil.rmtree(root, ignore_errors=True)
+            root.mkdir(parents=True, exist_ok=True)
+
+    def _materialize_compare_root(self, root: Path, paths: list[Path]) -> None:
+        """Write a lightweight filesystem mirror for a set of changed paths."""
+        normalized_paths = {path for path in paths if path.parts}
+        parent_directories = {parent for path in normalized_paths for parent in path.parents if parent.parts}
+
+        for directory in sorted(parent_directories, key=lambda item: (len(item.parts), item.as_posix())):
+            (root / directory).mkdir(parents=True, exist_ok=True)
+
+        for relative_path in sorted(normalized_paths, key=lambda item: item.as_posix()):
+            target = root / relative_path
+            if relative_path in parent_directories:
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.touch(exist_ok=True)
+
+    def _apply_compare_result(
+        self, result: DiffResult, path_states: dict[Path, ComparePathState], content_only: bool
+    ) -> None:
+        """Render the compare result after the background worker finishes."""
+        self._compare_result = result
+        self._path_states = path_states
+        self._set_compare_controls_enabled(True)
+        self.query_one("#archive-compare-status", Label).update(
+            self._render_status_line(result.archive1, result.archive2, content_only)
+        )
+        self.query_one("#archive-compare-summary", Static).update(self._render_summary(result))
+        self.query_one("#archive-compare-selection", Static).update(
+            "No changed paths to inspect." if not path_states else "No path selected."
+        )
+        self.query_one("#archive-compare-older-heading", Static).update(self._render_archive_heading(result.archive1))
+        self.query_one("#archive-compare-newer-heading", Static).update(self._render_archive_heading(result.archive2))
+
+        _ = self.query_one("#archive-compare-older-tree", DirectoryTree).reload()
+        _ = self.query_one("#archive-compare-newer-tree", DirectoryTree).reload()
+
+    def _on_compare_error(self, error: Exception) -> None:
+        """Handle archive compare failures."""
+        self._set_compare_controls_enabled(True)
+        self.query_one("#archive-compare-status", Label).update(f"Archive comparison failed: {error}")
+        self.query_one("#archive-compare-summary", Static).update(
+            f"[#f38ba8]Archive comparison failed:[/] {escape(str(error))}"
+        )
+        self.query_one("#archive-compare-selection", Static).update("No path selected.")
+        self.notify(str(error), severity="error", title="Archive Compare")
+
+    def _set_compare_controls_enabled(self, enabled: bool) -> None:
+        """Enable or disable compare controls while background work is running."""
+        self.query_one("#archive-compare-older-select", Select).disabled = not enabled
+        self.query_one("#archive-compare-newer-select", Select).disabled = not enabled
+        self.query_one("#archive-compare-content-only-switch", Switch).disabled = not enabled
+        self.query_one("#archive-compare-run-btn", Button).disabled = not enabled
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle compare button presses."""
+        if event.button.id != "archive-compare-run-btn":
+            return
+        self._start_compare()
+
+    def on_directory_tree_file_selected(self, event: DirectoryTree.FileSelected) -> None:
+        """Update the detail panel when a file is selected in either tree."""
+        self._show_selected_path(event.path)
+
+    def on_directory_tree_directory_selected(self, event: DirectoryTree.DirectorySelected) -> None:
+        """Update the detail panel when a directory is selected in either tree."""
+        self._show_selected_path(event.path)
+
+    def _show_selected_path(self, selected_path: Path) -> None:
+        """Render details for the selected compare path or directory."""
+        relative_path = self._relative_compare_path(selected_path)
+        if relative_path is None:
+            return
+
+        state = self._path_states.get(relative_path)
+        if state is not None:
+            changes = ", ".join(format_diff_change(change) for change in state.changes)
+            self.query_one("#archive-compare-selection", Static).update(
+                "\n".join(
+                    [
+                        f"[bold #f5e0dc]{escape(relative_path.as_posix())}[/]",
+                        f"[#89b4fa]Older:[/] {'Present' if state.older_exists else 'Missing'}",
+                        f"[#89b4fa]Newer:[/] {'Present' if state.newer_exists else 'Missing'}",
+                        f"[#89b4fa]Changes:[/] {escape(changes)}",
+                    ]
+                )
+            )
+            return
+
+        descendant_count = sum(
+            1 for path in self._path_states if relative_path == path or relative_path in path.parents
+        )
+        self.query_one("#archive-compare-selection", Static).update(
+            "\n".join(
+                [
+                    f"[bold #f5e0dc]{escape(relative_path.as_posix())}[/]",
+                    f"[#89b4fa]Changed descendants:[/] {descendant_count}",
+                ]
+            )
+        )
+
+    def _relative_compare_path(self, absolute_path: Path) -> Path | None:
+        """Convert an absolute selected path into a relative compare path."""
+        for root in (self._older_root, self._newer_root):
+            try:
+                return absolute_path.relative_to(root)
+            except ValueError:
+                continue
+        return None
+
+    def _render_archive_heading(self, archive_name: str) -> str:
+        """Render a heading for one side of the compare view."""
+        archive = self._archive_index.get(archive_name)
+        if archive is None:
+            return escape(archive_name)
+        return "\n".join(
+            [
+                f"[bold #f5e0dc]{escape(archive.name)}[/]",
+                f"[#89b4fa]{escape(format_iso_timestamp(archive.time or archive.start))}[/]",
+            ]
+        )
+
+    def _render_status_line(self, older_archive: str, newer_archive: str, content_only: bool) -> str:
+        """Render the current compare status line."""
+        content_label = "content-only" if content_only else "content + metadata"
+        return f"Comparing {older_archive} -> {newer_archive} ({content_label})."
+
+    def _render_summary(self, result: DiffResult) -> str:
+        """Render summary metrics for the current compare result."""
+        summary = summarize_diff_changes(result)
+        return "\n".join(
+            [
+                f"[bold #f5e0dc]{escape(result.archive1)}[/] [#89b4fa]->[/] [bold #f5e0dc]{escape(result.archive2)}[/]",
+                f"[#89b4fa]Changed paths:[/] {len(result.entries)}",
+                f"[#89b4fa]Added:[/] {summary['added']}  [#89b4fa]Removed:[/] {summary['removed']}",
+                f"[#89b4fa]Modified:[/] {summary['modified']}  [#89b4fa]Mode changes:[/] {summary['mode']}",
+                (
+                    f"[#89b4fa]Bytes added:[/] {escape(format_size_bytes(summary['bytes_added']))}  "
+                    f"[#89b4fa]Bytes removed:[/] {escape(format_size_bytes(summary['bytes_removed']))}"
+                ),
+            ]
+        )
+
+    def _cleanup_tempdir(self) -> None:
+        """Release the synthetic compare tree directory."""
+        self._tempdir.cleanup()

--- a/src/borgboi/tui/archive_compare_screen.py
+++ b/src/borgboi/tui/archive_compare_screen.py
@@ -9,6 +9,8 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
 
 from rich.markup import escape
+from rich.style import Style
+from rich.text import Text
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
@@ -43,6 +45,9 @@ class ComparePathState:
     changes: tuple[DiffChange, ...]
 
 
+CompareRowHighlight = Literal["green", "red"]
+
+
 def build_compare_path_states(result: DiffResult) -> dict[Path, ComparePathState]:
     """Build a lookup of changed paths and which side each path exists on."""
     states: dict[Path, ComparePathState] = {}
@@ -72,8 +77,66 @@ def _archive_sort_key(archive: RepoArchive) -> tuple[str, str]:
     return (archive.time or archive.start or "", archive.name)
 
 
+def build_compare_tree_highlights(
+    path_states: dict[Path, ComparePathState],
+) -> tuple[dict[Path, CompareRowHighlight], dict[Path, CompareRowHighlight]]:
+    """Build side-specific highlight maps for compare tree rows."""
+    older_highlights: dict[Path, CompareRowHighlight] = {}
+    newer_highlights: dict[Path, CompareRowHighlight] = {}
+
+    for state in path_states.values():
+        _record_compare_highlight(older_highlights, state.relative_path, _resolve_side_highlight(state, side="older"))
+        _record_compare_highlight(newer_highlights, state.relative_path, _resolve_side_highlight(state, side="newer"))
+
+    return older_highlights, newer_highlights
+
+
+def _resolve_side_highlight(state: ComparePathState, *, side: Literal["older", "newer"]) -> CompareRowHighlight | None:
+    """Resolve the row highlight for one path on one compare side."""
+    if side == "older":
+        if not state.older_exists:
+            return None
+        if not state.newer_exists:
+            return "red"
+        return "green"
+
+    if not state.newer_exists:
+        return None
+    return "green"
+
+
+def _record_compare_highlight(
+    highlights: dict[Path, CompareRowHighlight],
+    relative_path: Path,
+    highlight: CompareRowHighlight | None,
+) -> None:
+    """Apply one highlight to a path and its parent directories."""
+    if highlight is None or not relative_path.parts:
+        return
+
+    _merge_compare_highlight(highlights, relative_path, highlight)
+    for parent in relative_path.parents:
+        if parent.parts:
+            _merge_compare_highlight(highlights, parent, highlight)
+
+
+def _merge_compare_highlight(
+    highlights: dict[Path, CompareRowHighlight], relative_path: Path, highlight: CompareRowHighlight
+) -> None:
+    """Merge one highlight into the lookup, preferring green over red."""
+    current = highlights.get(relative_path)
+    if current == "green" or current == highlight:
+        return
+    highlights[relative_path] = highlight if highlight == "green" or current is None else current
+
+
 class CompareDirectoryTree(DirectoryTree):
     """Directory tree with compare-specific helpers and sync messages."""
+
+    ROW_HIGHLIGHT_STYLES: ClassVar[dict[CompareRowHighlight, Style]] = {
+        "green": Style.parse("on #213a2c"),
+        "red": Style.parse("on #3a2430"),
+    }
 
     class DirectoryExpanded(Message):
         """Posted when a directory node is expanded."""
@@ -101,6 +164,8 @@ class CompareDirectoryTree(DirectoryTree):
         disabled: bool = False,
     ) -> None:
         super().__init__(path, name=name, id=id, classes=classes, disabled=disabled)
+        self._compare_root_resolved = Path(path).resolve()
+        self._row_highlights: dict[Path, CompareRowHighlight] = {}
 
     def on_tree_node_expanded(self, event: Tree.NodeExpanded[DirEntry]) -> None:
         """Relay directory expansion through a public custom message."""
@@ -139,6 +204,32 @@ class CompareDirectoryTree(DirectoryTree):
             current_node = child_node
 
         return current_node
+
+    def set_row_highlights(self, highlights: dict[Path, CompareRowHighlight]) -> None:
+        """Replace the row highlight map for this tree."""
+        self._row_highlights = highlights
+        self.refresh()
+
+    def render_label(self, node: TreeNode[DirEntry], base_style: Style, style: Style) -> Text:
+        """Render a label with compare-specific tinting for changed paths."""
+        highlight = self._highlight_for_node(node)
+        if highlight is None:
+            return super().render_label(node, base_style, style)
+
+        highlight_style = self.ROW_HIGHLIGHT_STYLES[highlight]
+        return super().render_label(node, base_style + highlight_style, style + highlight_style)
+
+    def _highlight_for_node(self, node: TreeNode[DirEntry]) -> CompareRowHighlight | None:
+        """Return the compare highlight for a tree node, if any."""
+        if node.data is None:
+            return None
+
+        try:
+            relative_path = node.data.path.resolve().relative_to(self._compare_root_resolved)
+        except ValueError:
+            return None
+
+        return self._row_highlights.get(relative_path)
 
 
 class ArchiveCompareScreen(Screen[None]):
@@ -379,6 +470,9 @@ class ArchiveCompareScreen(Screen[None]):
         self.query_one("#archive-compare-older-heading", Static).update(self._render_archive_heading(result.archive1))
         self.query_one("#archive-compare-newer-heading", Static).update(self._render_archive_heading(result.archive2))
         self.expanded_paths = frozenset()
+        older_highlights, newer_highlights = build_compare_tree_highlights(path_states)
+        self._older_tree.set_row_highlights(older_highlights)
+        self._newer_tree.set_row_highlights(newer_highlights)
 
         _ = self._older_tree.reload()
         _ = self._newer_tree.reload()

--- a/src/borgboi/tui/archive_compare_screen.py
+++ b/src/borgboi/tui/archive_compare_screen.py
@@ -761,4 +761,11 @@ class ArchiveCompareScreen(Screen[None]):
 
     def _cleanup_tempdir(self) -> None:
         """Release the synthetic compare tree directory."""
-        self._tempdir.cleanup()
+        try:
+            self._tempdir.cleanup()
+        except OSError as exc:
+            logger.warning(
+                "Failed to clean up temporary compare directory",
+                tempdir=self._compare_temp_root.as_posix(),
+                error=str(exc),
+            )

--- a/src/borgboi/tui/archive_compare_screen.py
+++ b/src/borgboi/tui/archive_compare_screen.py
@@ -46,6 +46,7 @@ class ComparePathState:
 
 
 CompareRowHighlight = Literal["green", "red"]
+ComparePathKind = Literal["added", "removed", "modified"]
 
 
 def build_compare_path_states(result: DiffResult) -> dict[Path, ComparePathState]:
@@ -80,7 +81,7 @@ def _archive_sort_key(archive: RepoArchive) -> tuple[str, str]:
 def build_compare_tree_highlights(
     path_states: dict[Path, ComparePathState],
 ) -> tuple[dict[Path, CompareRowHighlight], dict[Path, CompareRowHighlight]]:
-    """Build side-specific highlight maps for compare tree rows."""
+    """Build side-specific direct highlight maps for compare tree rows."""
     older_highlights: dict[Path, CompareRowHighlight] = {}
     newer_highlights: dict[Path, CompareRowHighlight] = {}
 
@@ -91,18 +92,50 @@ def build_compare_tree_highlights(
     return older_highlights, newer_highlights
 
 
+def build_compare_tree_modified_paths(path_states: dict[Path, ComparePathState]) -> tuple[set[Path], set[Path]]:
+    """Build side-specific direct modified-path markers for compare tree rows."""
+    older_modified = _build_side_modified_paths(path_states, side="older")
+    newer_modified = _build_side_modified_paths(path_states, side="newer")
+    return older_modified, newer_modified
+
+
+def build_compare_tree_parent_indicators(path_states: dict[Path, ComparePathState]) -> tuple[set[Path], set[Path]]:
+    """Build side-specific ancestor directories that contain changed descendants."""
+    older_indicators = _build_side_parent_indicators(path_states, side="older")
+    newer_indicators = _build_side_parent_indicators(path_states, side="newer")
+    return older_indicators, newer_indicators
+
+
 def _resolve_side_highlight(state: ComparePathState, *, side: Literal["older", "newer"]) -> CompareRowHighlight | None:
     """Resolve the row highlight for one path on one compare side."""
-    if side == "older":
-        if not state.older_exists:
-            return None
-        if not state.newer_exists:
-            return "red"
+    path_kind = _resolve_path_kind(state)
+    if path_kind == "removed" and side == "older":
+        return "red"
+    if path_kind == "added" and side == "newer":
         return "green"
+    return None
 
-    if not state.newer_exists:
-        return None
-    return "green"
+
+def _resolve_path_kind(state: ComparePathState) -> ComparePathKind:
+    """Classify one changed path as added, removed, or modified."""
+    change_types = {change.type for change in state.changes}
+    if change_types == {"added"}:
+        return "added"
+    if change_types == {"removed"}:
+        return "removed"
+    return "modified"
+
+
+def _path_exists_on_side(state: ComparePathState, *, side: Literal["older", "newer"]) -> bool:
+    """Return whether a changed path exists on one side of the compare."""
+    if side == "older":
+        return state.older_exists
+    return state.newer_exists
+
+
+def _is_directly_modified_on_side(state: ComparePathState, *, side: Literal["older", "newer"]) -> bool:
+    """Return whether a changed path should show a direct modified marker on one side."""
+    return _resolve_path_kind(state) == "modified" and _path_exists_on_side(state, side=side)
 
 
 def _record_compare_highlight(
@@ -110,14 +143,61 @@ def _record_compare_highlight(
     relative_path: Path,
     highlight: CompareRowHighlight | None,
 ) -> None:
-    """Apply one highlight to a path and its parent directories."""
+    """Apply one highlight to the changed path itself."""
     if highlight is None or not relative_path.parts:
         return
 
     _merge_compare_highlight(highlights, relative_path, highlight)
-    for parent in relative_path.parents:
-        if parent.parts:
-            _merge_compare_highlight(highlights, parent, highlight)
+
+
+def _build_side_modified_paths(
+    path_states: dict[Path, ComparePathState], *, side: Literal["older", "newer"]
+) -> set[Path]:
+    """Collect directly modified paths that should show a dim modified marker."""
+    return {
+        state.relative_path
+        for state in path_states.values()
+        if state.relative_path.parts and _is_directly_modified_on_side(state, side=side)
+    }
+
+
+def _build_side_visible_changed_paths(
+    path_states: dict[Path, ComparePathState], *, side: Literal["older", "newer"]
+) -> set[Path]:
+    """Collect changed paths visible on one compare side."""
+    return {
+        state.relative_path
+        for state in path_states.values()
+        if state.relative_path.parts and _path_exists_on_side(state, side=side)
+    }
+
+
+def _build_side_direct_marker_paths(
+    path_states: dict[Path, ComparePathState], *, side: Literal["older", "newer"]
+) -> set[Path]:
+    """Collect direct paths that render their own special state on one side."""
+    return {
+        state.relative_path
+        for state in path_states.values()
+        if state.relative_path.parts
+        and (_resolve_side_highlight(state, side=side) is not None or _is_directly_modified_on_side(state, side=side))
+    }
+
+
+def _build_side_parent_indicators(
+    path_states: dict[Path, ComparePathState], *, side: Literal["older", "newer"]
+) -> set[Path]:
+    """Collect ancestor directories that should show a dim modified marker."""
+    indicators: set[Path] = set()
+    visible_paths = _build_side_visible_changed_paths(path_states, side=side)
+    direct_marker_paths = _build_side_direct_marker_paths(path_states, side=side)
+
+    for visible_path in visible_paths:
+        for parent in visible_path.parents:
+            if parent.parts and parent not in direct_marker_paths:
+                indicators.add(parent)
+
+    return indicators
 
 
 def _merge_compare_highlight(
@@ -166,6 +246,8 @@ class CompareDirectoryTree(DirectoryTree):
         super().__init__(path, name=name, id=id, classes=classes, disabled=disabled)
         self._compare_root_resolved = Path(path).resolve()
         self._row_highlights: dict[Path, CompareRowHighlight] = {}
+        self._modified_paths: set[Path] = set()
+        self._modified_parent_paths: set[Path] = set()
 
     def on_tree_node_expanded(self, event: Tree.NodeExpanded[DirEntry]) -> None:
         """Relay directory expansion through a public custom message."""
@@ -210,26 +292,53 @@ class CompareDirectoryTree(DirectoryTree):
         self._row_highlights = highlights
         self.refresh()
 
+    def set_modified_paths(self, modified_paths: set[Path]) -> None:
+        """Replace the direct modified-path marker set for this tree."""
+        self._modified_paths = modified_paths
+        self.refresh()
+
+    def set_modified_parent_paths(self, parent_paths: set[Path]) -> None:
+        """Replace the parent-directory indicator set for this tree."""
+        self._modified_parent_paths = parent_paths
+        self.refresh()
+
+    @override
     def render_label(self, node: TreeNode[DirEntry], base_style: Style, style: Style) -> Text:
-        """Render a label with compare-specific tinting for changed paths."""
+        """Render a label with compare-specific tinting and parent indicators."""
         highlight = self._highlight_for_node(node)
+        label = super().render_label(node, base_style, style)
         if highlight is None:
-            return super().render_label(node, base_style, style)
+            if self._shows_modified_marker(node):
+                label.append(" (modified)", Style.parse("dim #7f849c"))
+            return label
 
         highlight_style = self.ROW_HIGHLIGHT_STYLES[highlight]
         return super().render_label(node, base_style + highlight_style, style + highlight_style)
 
     def _highlight_for_node(self, node: TreeNode[DirEntry]) -> CompareRowHighlight | None:
         """Return the compare highlight for a tree node, if any."""
+        relative_path = self._relative_path_for_node(node)
+        if relative_path is None:
+            return None
+
+        return self._row_highlights.get(relative_path)
+
+    def _shows_modified_marker(self, node: TreeNode[DirEntry]) -> bool:
+        """Return whether a node should show the dim modified marker."""
+        relative_path = self._relative_path_for_node(node)
+        if relative_path is None:
+            return False
+        return relative_path in self._modified_paths or relative_path in self._modified_parent_paths
+
+    def _relative_path_for_node(self, node: TreeNode[DirEntry]) -> Path | None:
+        """Resolve the compare-relative path for one tree node."""
         if node.data is None:
             return None
 
         try:
-            relative_path = node.data.path.resolve().relative_to(self._compare_root_resolved)
+            return node.data.path.resolve().relative_to(self._compare_root_resolved)
         except ValueError:
             return None
-
-        return self._row_highlights.get(relative_path)
 
 
 class ArchiveCompareScreen(Screen[None]):
@@ -471,8 +580,14 @@ class ArchiveCompareScreen(Screen[None]):
         self.query_one("#archive-compare-newer-heading", Static).update(self._render_archive_heading(result.archive2))
         self.expanded_paths = frozenset()
         older_highlights, newer_highlights = build_compare_tree_highlights(path_states)
+        older_modified_paths, newer_modified_paths = build_compare_tree_modified_paths(path_states)
+        older_parent_indicators, newer_parent_indicators = build_compare_tree_parent_indicators(path_states)
         self._older_tree.set_row_highlights(older_highlights)
         self._newer_tree.set_row_highlights(newer_highlights)
+        self._older_tree.set_modified_paths(older_modified_paths)
+        self._newer_tree.set_modified_paths(newer_modified_paths)
+        self._older_tree.set_modified_parent_paths(older_parent_indicators)
+        self._newer_tree.set_modified_parent_paths(newer_parent_indicators)
 
         _ = self._older_tree.reload()
         _ = self._newer_tree.reload()

--- a/src/borgboi/tui/archive_compare_screen.py
+++ b/src/borgboi/tui/archive_compare_screen.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import shutil
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, ClassVar, override
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
 
 from rich.markup import escape
 from textual import work
@@ -14,7 +15,9 @@ from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, Vertical
 from textual.screen import Screen
-from textual.widgets import Button, DirectoryTree, Footer, Header, Label, Select, Static, Switch
+from textual.widgets import Button, DirectoryTree, Footer, Header, Label, Select, Static, Switch, Tree
+from textual.widgets.directory_tree import DirEntry
+from textual.widgets.tree import TreeNode
 
 from borgboi.clients.borg import DiffChange, DiffResult, RepoArchive
 from borgboi.core.logging import get_logger
@@ -68,6 +71,67 @@ def _archive_sort_key(archive: RepoArchive) -> tuple[str, str]:
     return (archive.time or archive.start or "", archive.name)
 
 
+class CompareDirectoryTree(DirectoryTree):
+    """Directory tree that reports directory expand/collapse changes to the screen."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        on_directory_expanded: Callable[[CompareDirectoryTree, Path], Awaitable[None]] | None = None,
+        on_directory_collapsed: Callable[[CompareDirectoryTree, Path], Awaitable[None]] | None = None,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False,
+    ) -> None:
+        self._on_directory_expanded = on_directory_expanded
+        self._on_directory_collapsed = on_directory_collapsed
+        super().__init__(path, name=name, id=id, classes=classes, disabled=disabled)
+
+    @override
+    async def _on_tree_node_expanded(self, event: Tree.NodeExpanded[DirEntry]) -> None:
+        """Emit a screen-friendly message after Textual finishes loading a directory."""
+        await super()._on_tree_node_expanded(event)
+        dir_entry = event.node.data
+        if dir_entry is None or not event.node.allow_expand:
+            return
+        if self._on_directory_expanded is not None:
+            await self._on_directory_expanded(self, dir_entry.path)
+
+    async def _on_tree_node_collapsed(self, event: Tree.NodeCollapsed[DirEntry]) -> None:
+        """Emit a screen-friendly message after a directory node is collapsed."""
+        dir_entry = event.node.data
+        if dir_entry is None or not event.node.allow_expand:
+            return
+        if self._on_directory_collapsed is not None:
+            await self._on_directory_collapsed(self, dir_entry.path)
+
+    async def ensure_node_loaded(self, node: TreeNode[DirEntry]) -> None:
+        """Ensure a directory node's children are loaded into memory."""
+        if not node.allow_expand or node.data is None or node.data.loaded:
+            return
+        await self._add_to_load_queue(node)
+
+    async def find_node_by_relative_path(self, relative_path: Path) -> TreeNode[DirEntry] | None:
+        """Locate a node by relative path, loading ancestor directories as needed."""
+        current_node = self.root
+        if not relative_path.parts:
+            return current_node
+
+        for part in relative_path.parts:
+            await self.ensure_node_loaded(current_node)
+            child_node: TreeNode[DirEntry] | None = next(
+                (child for child in current_node.children if child.data is not None and child.data.path.name == part),
+                None,
+            )
+            if child_node is None:
+                return None
+            current_node = child_node
+
+        return current_node
+
+
 class ArchiveCompareScreen(Screen[None]):
     """Screen for visually comparing two archives from the same repository."""
 
@@ -97,6 +161,9 @@ class ArchiveCompareScreen(Screen[None]):
         self._compare_temp_root = Path(self._tempdir.name)
         self._older_root = self._compare_temp_root / "older"
         self._newer_root = self._compare_temp_root / "newer"
+        self._older_root_resolved = self._older_root.resolve()
+        self._newer_root_resolved = self._newer_root.resolve()
+        self._mirrored_tree_operations: set[tuple[str, str, str]] = set()
         self._older_root.mkdir(parents=True, exist_ok=True)
         self._newer_root.mkdir(parents=True, exist_ok=True)
         super().__init__(**kwargs)
@@ -112,7 +179,12 @@ class ArchiveCompareScreen(Screen[None]):
                 with Vertical(classes="archive-compare-pane"):
                     yield Select[str]([], prompt="Older archive", id="archive-compare-older-select", disabled=True)
                     yield Static("Older archive", id="archive-compare-older-heading", markup=True)
-                    yield DirectoryTree(self._older_root, id="archive-compare-older-tree")
+                    yield CompareDirectoryTree(
+                        self._older_root,
+                        id="archive-compare-older-tree",
+                        on_directory_expanded=self._mirror_directory_expansion,
+                        on_directory_collapsed=self._mirror_directory_collapse,
+                    )
                 with Vertical(id="archive-compare-details", classes="archive-compare-pane"):
                     with Horizontal(id="archive-compare-center-controls"):
                         yield Label("Content only", id="archive-compare-content-only-label")
@@ -123,13 +195,19 @@ class ArchiveCompareScreen(Screen[None]):
                 with Vertical(classes="archive-compare-pane"):
                     yield Select[str]([], prompt="Newer archive", id="archive-compare-newer-select", disabled=True)
                     yield Static("Newer archive", id="archive-compare-newer-heading", markup=True)
-                    yield DirectoryTree(self._newer_root, id="archive-compare-newer-tree")
+                    yield CompareDirectoryTree(
+                        self._newer_root,
+                        id="archive-compare-newer-tree",
+                        on_directory_expanded=self._mirror_directory_expansion,
+                        on_directory_collapsed=self._mirror_directory_collapse,
+                    )
         yield Footer()
 
     def on_mount(self) -> None:
         """Prepare the trees and start loading archive choices."""
-        for tree_id in ("#archive-compare-older-tree", "#archive-compare-newer-tree"):
-            tree = self.query_one(tree_id, DirectoryTree)
+        self._older_tree = self.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        self._newer_tree = self.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
+        for tree in (self._older_tree, self._newer_tree):
             tree.show_root = False
             tree.root.expand()
 
@@ -294,9 +372,10 @@ class ArchiveCompareScreen(Screen[None]):
         )
         self.query_one("#archive-compare-older-heading", Static).update(self._render_archive_heading(result.archive1))
         self.query_one("#archive-compare-newer-heading", Static).update(self._render_archive_heading(result.archive2))
+        self._mirrored_tree_operations.clear()
 
-        _ = self.query_one("#archive-compare-older-tree", DirectoryTree).reload()
-        _ = self.query_one("#archive-compare-newer-tree", DirectoryTree).reload()
+        _ = self._older_tree.reload()
+        _ = self._newer_tree.reload()
 
     def _on_compare_error(self, error: Exception) -> None:
         """Handle archive compare failures."""
@@ -328,6 +407,49 @@ class ArchiveCompareScreen(Screen[None]):
     def on_directory_tree_directory_selected(self, event: DirectoryTree.DirectorySelected) -> None:
         """Update the detail panel when a directory is selected in either tree."""
         self._show_selected_path(event.path)
+
+    async def _mirror_directory_expansion(self, source_tree: CompareDirectoryTree, expanded_path: Path) -> None:
+        """Mirror user-driven directory expansions into the opposite archive tree."""
+        await self._sync_directory_state(source_tree, expanded_path, operation="expand")
+
+    async def _mirror_directory_collapse(self, source_tree: CompareDirectoryTree, collapsed_path: Path) -> None:
+        """Mirror user-driven directory collapses into the opposite archive tree."""
+        await self._sync_directory_state(source_tree, collapsed_path, operation="collapse")
+
+    async def _sync_directory_state(
+        self, source_tree: CompareDirectoryTree, directory_path: Path, *, operation: Literal["expand", "collapse"]
+    ) -> None:
+        """Synchronize a directory expand/collapse operation into the opposite tree."""
+        relative_path = self._relative_compare_path(directory_path)
+        if relative_path is None or not relative_path.parts:
+            return
+
+        message_key = (operation, source_tree.id or "", relative_path.as_posix())
+        if message_key in self._mirrored_tree_operations:
+            self._mirrored_tree_operations.remove(message_key)
+            return
+
+        peer_tree = self._get_peer_tree(source_tree)
+        if peer_tree is None:
+            return
+
+        matching_node = await peer_tree.find_node_by_relative_path(relative_path)
+        if matching_node is None or not matching_node.allow_expand:
+            return
+
+        if operation == "expand":
+            if matching_node.is_expanded:
+                return
+            self._mirrored_tree_operations.add((operation, peer_tree.id or "", relative_path.as_posix()))
+            matching_node.expand()
+            await peer_tree.ensure_node_loaded(matching_node)
+            return
+
+        if operation == "collapse":
+            if matching_node.is_collapsed:
+                return
+            self._mirrored_tree_operations.add((operation, peer_tree.id or "", relative_path.as_posix()))
+            matching_node.collapse()
 
     def _show_selected_path(self, selected_path: Path) -> None:
         """Render details for the selected compare path or directory."""
@@ -364,11 +486,20 @@ class ArchiveCompareScreen(Screen[None]):
 
     def _relative_compare_path(self, absolute_path: Path) -> Path | None:
         """Convert an absolute selected path into a relative compare path."""
-        for root in (self._older_root, self._newer_root):
+        resolved_path = absolute_path.resolve()
+        for root in (self._older_root_resolved, self._newer_root_resolved):
             try:
-                return absolute_path.relative_to(root)
+                return resolved_path.relative_to(root)
             except ValueError:
                 continue
+        return None
+
+    def _get_peer_tree(self, source_tree: CompareDirectoryTree) -> CompareDirectoryTree | None:
+        """Return the opposite compare tree for a given source tree."""
+        if source_tree is self._older_tree:
+            return self._newer_tree
+        if source_tree is self._newer_tree:
+            return self._older_tree
         return None
 
     def _render_archive_heading(self, archive_name: str) -> str:

--- a/src/borgboi/tui/borgboi.tcss
+++ b/src/borgboi/tui/borgboi.tcss
@@ -448,6 +448,96 @@ CollapsibleTitle:hover {
     margin-bottom: 1;
 }
 
+#repo-info-archives-actions {
+    height: auto;
+    align: left middle;
+    margin-bottom: 1;
+}
+
+#repo-info-compare-archives-btn {
+    margin-right: 1;
+}
+
+/* Archive compare screen */
+
+#archive-compare-screen {
+    height: 1fr;
+    background: #1e1e2e;
+    padding: 1 2;
+}
+
+#archive-compare-title {
+    color: #cba6f7;
+    text-style: bold;
+    padding-bottom: 1;
+}
+
+#archive-compare-status,
+#archive-compare-summary,
+#archive-compare-selection,
+#archive-compare-older-heading,
+#archive-compare-newer-heading,
+#archive-compare-content-only-label {
+    color: #cdd6f4;
+}
+
+#archive-compare-status,
+#archive-compare-summary,
+#archive-compare-selection {
+    margin-bottom: 1;
+}
+
+#archive-compare-older-select,
+#archive-compare-newer-select {
+    width: 100%;
+    margin-bottom: 1;
+}
+
+#archive-compare-center-controls {
+    height: auto;
+    align: center middle;
+    margin-bottom: 1;
+}
+
+#archive-compare-content-only-label {
+    padding: 1 1 0 0;
+}
+
+#archive-compare-content-only-switch {
+    margin-right: 1;
+}
+
+#archive-compare-body {
+    height: 1fr;
+}
+
+.archive-compare-pane {
+    width: 1fr;
+    height: 1fr;
+    border: round #45475a;
+    background: #181825;
+    color: #cdd6f4;
+    padding: 1 2;
+    margin-right: 1;
+}
+
+#archive-compare-body .archive-compare-pane:last-child {
+    margin-right: 0;
+}
+
+#archive-compare-details {
+    min-width: 40;
+}
+
+#archive-compare-older-tree,
+#archive-compare-newer-tree {
+    height: 1fr;
+    border: round #313244;
+    background: #11111b;
+    color: #cdd6f4;
+    margin-top: 1;
+}
+
 #daily-backup-log {
     height: 1fr;
     border: round #313244;

--- a/src/borgboi/tui/repo_info_screen.py
+++ b/src/borgboi/tui/repo_info_screen.py
@@ -161,6 +161,7 @@ class RepoInfoScreen(Screen[None]):
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "back", "Back"),
         Binding("b", "daily_backup", "Backup"),
+        Binding("d", "compare_archives", "Compare"),
         Binding("e", "edit_config", "Edit Config"),
         Binding("r", "refresh", "Refresh"),
     ]
@@ -233,6 +234,13 @@ class RepoInfoScreen(Screen[None]):
 
                 with TabPane("Archives", id="repo-info-archives-tab"), Vertical(classes="repo-info-tab-body"):
                     yield Label("", id="repo-info-archives-status")
+                    with Horizontal(id="repo-info-archives-actions"):
+                        yield Button(
+                            "Compare archives",
+                            id="repo-info-compare-archives-btn",
+                            variant="primary",
+                            disabled=not self._is_local_repo(),
+                        )
                     yield DataTable(id="repo-info-archives-table")
 
                 with (
@@ -300,6 +308,29 @@ class RepoInfoScreen(Screen[None]):
         self._load_repo_details()
         if self._is_local_repo():
             self._load_live_quota()
+
+    def action_compare_archives(self) -> None:
+        """Open the archive compare screen for the current repository."""
+        if not self._is_local_repo():
+            self.notify("Archive comparison is only available for repositories on this machine.", severity="warning")
+            return
+
+        table = self.query_one("#repo-info-archives-table", DataTable)
+        if table.row_count < 2:
+            self.notify("This repository needs at least two archives to compare.", severity="warning")
+            return
+
+        from borgboi.tui.archive_compare_screen import ArchiveCompareScreen
+
+        older_archive, newer_archive = self._default_compare_archives()
+        _ = self.app.push_screen(
+            ArchiveCompareScreen(
+                repo=self._repo,
+                orchestrator=self._orchestrator,
+                initial_older_archive=older_archive,
+                initial_newer_archive=newer_archive,
+            )
+        )
 
     def action_edit_config(self) -> None:
         """Open the dedicated repo settings editor screen."""
@@ -411,9 +442,11 @@ class RepoInfoScreen(Screen[None]):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses in the repo info screen."""
-        if event.button.id != "repo-info-edit-config-btn":
+        if event.button.id == "repo-info-edit-config-btn":
+            self.action_edit_config()
             return
-        self.action_edit_config()
+        if event.button.id == "repo-info-compare-archives-btn":
+            self.action_compare_archives()
 
     def _apply_config_result(self, result: RepoConfigResult) -> None:
         """Apply the config editor result to the parent summary state."""
@@ -649,9 +682,13 @@ class RepoInfoScreen(Screen[None]):
 
         if not archives:
             self.query_one("#repo-info-archives-status", Static).update("No archives found for this repository.")
+            self.query_one("#repo-info-compare-archives-btn", Button).disabled = True
             return
 
         self.query_one("#repo-info-archives-status", Static).update(f"{len(archives)} archives found.")
+        self.query_one("#repo-info-compare-archives-btn", Button).disabled = not (
+            self._is_local_repo() and len(archives) >= 2
+        )
         for archive in archives:
             table.add_row(
                 archive.name,
@@ -659,6 +696,19 @@ class RepoInfoScreen(Screen[None]):
                 _format_archive_age(archive.name),
                 archive.id[:12],
             )
+
+    def _default_compare_archives(self) -> tuple[str | None, str | None]:
+        """Return the older/newer archive names from the current archive table selection."""
+        table = self.query_one("#repo-info-archives-table", DataTable)
+        rows: list[str] = []
+        for row_index in range(table.row_count):
+            row_key = table.get_row_at(row_index)
+            rows.append(str(row_key[0]))
+
+        if len(rows) < 2:
+            return None, None
+
+        return rows[1], rows[0]
 
     def _on_load_error(self, error: Exception) -> None:
         """Handle live data loading failures."""
@@ -675,4 +725,5 @@ class RepoInfoScreen(Screen[None]):
         self.query_one("#repo-info-command-output", Static).update(_render_fields([("Error", str(error))]))
         self.query_one("#repo-info-archives-status", Static).update("Archive list unavailable.")
         self.query_one("#repo-info-archives-table", DataTable).clear()
+        self.query_one("#repo-info-compare-archives-btn", Button).disabled = True
         self.notify(str(error), severity="error", title="Failed to load repo info")

--- a/src/borgboi/tui/repo_info_screen.py
+++ b/src/borgboi/tui/repo_info_screen.py
@@ -160,6 +160,7 @@ class RepoInfoScreen(Screen[None]):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "back", "Back"),
+        Binding("a", "show_archives", "Archives"),
         Binding("b", "daily_backup", "Backup"),
         Binding("d", "compare_archives", "Compare"),
         Binding("e", "edit_config", "Edit Config"),
@@ -331,6 +332,11 @@ class RepoInfoScreen(Screen[None]):
                 initial_newer_archive=newer_archive,
             )
         )
+
+    def action_show_archives(self) -> None:
+        """Open the Archives tab and focus the archive table."""
+        self.query_one("#repo-info-tabs", TabbedContent).active = "repo-info-archives-tab"
+        self.query_one("#repo-info-archives-table", DataTable).focus()
 
     def action_edit_config(self) -> None:
         """Open the dedicated repo settings editor screen."""

--- a/tests/backup_cli_test.py
+++ b/tests/backup_cli_test.py
@@ -276,7 +276,7 @@ def test_backup_daily_rejects_both_name_and_path(tmp_path: Path, capsys: pytest.
     assert "mutually exclusive" in captured.out
 
 
-def testsummarize_diff_changes_counts_entries_by_type() -> None:
+def test_summarize_diff_changes_counts_entries_by_type() -> None:
     result = DiffResult.model_validate(
         {
             "archive1": "archive-old",
@@ -306,7 +306,7 @@ def testsummarize_diff_changes_counts_entries_by_type() -> None:
     }
 
 
-def testformat_diff_change_includes_metadata_values() -> None:
+def test_format_diff_change_includes_metadata_values() -> None:
     result = DiffResult.model_validate(
         {
             "archive1": "archive-old",

--- a/tests/backup_cli_test.py
+++ b/tests/backup_cli_test.py
@@ -8,12 +8,11 @@ from inline_snapshot import snapshot
 
 from borgboi.cli.backup import (
     _build_archive_stats_tables,
-    _format_diff_change,
     _render_diff_result,
-    _summarize_diff_changes,
 )
 from borgboi.clients.borg import ArchiveInfo, DiffResult
 from borgboi.core.models import BackupOptions, DiffOptions
+from borgboi.lib.diff import format_diff_change, summarize_diff_changes
 from tests.cli_helpers import invoke_cli
 
 cli_main = importlib.import_module("borgboi.cli.main")
@@ -277,7 +276,7 @@ def test_backup_daily_rejects_both_name_and_path(tmp_path: Path, capsys: pytest.
     assert "mutually exclusive" in captured.out
 
 
-def test_summarize_diff_changes_counts_entries_by_type() -> None:
+def testsummarize_diff_changes_counts_entries_by_type() -> None:
     result = DiffResult.model_validate(
         {
             "archive1": "archive-old",
@@ -297,7 +296,7 @@ def test_summarize_diff_changes_counts_entries_by_type() -> None:
         }
     )
 
-    assert _summarize_diff_changes(result) == {
+    assert summarize_diff_changes(result) == {
         "added": 1,
         "removed": 1,
         "modified": 1,
@@ -307,7 +306,7 @@ def test_summarize_diff_changes_counts_entries_by_type() -> None:
     }
 
 
-def test_format_diff_change_includes_metadata_values() -> None:
+def testformat_diff_change_includes_metadata_values() -> None:
     result = DiffResult.model_validate(
         {
             "archive1": "archive-old",
@@ -327,7 +326,7 @@ def test_format_diff_change_includes_metadata_values() -> None:
         }
     )
 
-    assert _format_diff_change(result.entries[0].changes[0]) == "mtime 2026-04-03T10:00:00 -> 2026-04-03T11:00:00"
+    assert format_diff_change(result.entries[0].changes[0]) == "mtime 2026-04-03T10:00:00 -> 2026-04-03T11:00:00"
 
 
 def test_render_diff_result_json_outputs_raw_json(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/tui/app_test.py
+++ b/tests/tui/app_test.py
@@ -31,8 +31,12 @@ async def test_app_loads_and_populates_repos_table(tui_config: Config) -> None:
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
-        await pilot.pause()
+        # Wait for repos to load via worker
         table = app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if table.row_count == 2:
+                break
         assert table.row_count == 2
 
 
@@ -91,7 +95,12 @@ async def test_action_show_repo_info_pushes_screen(tui_config: Config, repo_with
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
-        await pilot.pause()
+        # Wait for repos to load and table to be populated
+        table = app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if table.row_count > 0:
+                break
         await pilot.press("i")
         await pilot.pause()
         assert isinstance(app.screen, RepoInfoScreen)
@@ -115,7 +124,12 @@ async def test_repo_table_row_selected_opens_repo_info_screen(
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
-        await pilot.pause()
+        # Wait for repos to load and table to be populated
+        table = app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if table.row_count > 0:
+                break
         await pilot.press("enter")
         await pilot.pause()
         assert isinstance(app.screen, RepoInfoScreen)
@@ -211,11 +225,20 @@ async def test_action_refresh_reloads_repos(tui_config: Config) -> None:
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
-        await pilot.pause()  # initial load
+        # Wait for initial load
+        table = app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if not table.loading:
+                break
         initial_count = call_count
 
         await pilot.press("r")
-        await pilot.pause()
+        # Wait for refresh to increase call count
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if call_count > initial_count:
+                break
         assert call_count > initial_count
 
 
@@ -248,7 +271,12 @@ async def test_app_loads_sparkline_history_from_configured_db(
     expected_labels = [(today - timedelta(days=13 - index)).strftime("%m/%d") for index in range(14)]
 
     async with app.run_test() as pilot:
-        await pilot.pause()
+        # Wait for sparkline labels to be populated
+        for _ in range(50):
+            await pilot.pause(0.05)
+            label = app.query_one("#sparkline-x-label-0", Static)
+            if label.content:
+                break
         actual_labels = [app.query_one(f"#sparkline-x-label-{index}", Static).content for index in range(14)]
         assert actual_labels == expected_labels
 
@@ -263,7 +291,11 @@ async def test_load_repos_error_shows_notification(tui_config: Config) -> None:
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
-        await pilot.pause()
+        # Wait for loading to complete (even with error)
         table = app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if not table.loading:
+                break
         assert table.loading is False
         assert table.row_count == 0

--- a/tests/tui/archive_compare_screen_test.py
+++ b/tests/tui/archive_compare_screen_test.py
@@ -146,12 +146,13 @@ async def test_archive_compare_screen_mirrors_directory_expansion_when_path_exis
         for _ in range(40):
             await pilot.pause(0.05)
             newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
-            if newer_docs is not None and newer_docs.is_expanded:
+            if newer_docs is not None and newer_docs.is_expanded and screen.expanded_paths == frozenset({"docs"}):
                 break
 
         assert older_docs.is_expanded is True
         assert newer_docs is not None
         assert newer_docs.is_expanded is True
+        assert screen.expanded_paths == frozenset({"docs"})
 
 
 async def test_archive_compare_screen_mirrors_directory_collapse_when_path_exists(
@@ -185,12 +186,13 @@ async def test_archive_compare_screen_mirrors_directory_collapse_when_path_exist
         for _ in range(40):
             await pilot.pause(0.05)
             newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
-            if newer_docs is not None and newer_docs.is_collapsed:
+            if newer_docs is not None and newer_docs.is_collapsed and screen.expanded_paths == frozenset():
                 break
 
         assert older_docs.is_collapsed is True
         assert newer_docs is not None
         assert newer_docs.is_collapsed is True
+        assert screen.expanded_paths == frozenset()
 
 
 async def test_archive_compare_screen_ignores_missing_matching_directory(archive_compare_app: BorgBoiApp) -> None:
@@ -212,6 +214,49 @@ async def test_archive_compare_screen_ignores_missing_matching_directory(archive
 
         assert older_only.is_expanded is True
         assert await newer_tree.find_node_by_relative_path(Path("only-older")) is None
+        assert screen.expanded_paths == frozenset({"only-older"})
+
+
+async def test_archive_compare_screen_resets_expansion_state_on_new_compare(archive_compare_app: BorgBoiApp) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+
+        older_tree = screen.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        newer_tree = screen.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
+        older_docs = await older_tree.find_node_by_relative_path(Path("docs"))
+        newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+
+        assert older_docs is not None
+        older_docs.expand()
+
+        for _ in range(40):
+            await pilot.pause(0.05)
+            newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+            if newer_docs is not None and newer_docs.is_expanded and screen.expanded_paths == frozenset({"docs"}):
+                break
+
+        assert screen.expanded_paths == frozenset({"docs"})
+
+        screen.action_run_compare()
+
+        for _ in range(60):
+            await pilot.pause(0.05)
+            older_docs = await older_tree.find_node_by_relative_path(Path("docs"))
+            newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+            if (
+                screen.expanded_paths == frozenset()
+                and older_docs is not None
+                and newer_docs is not None
+                and older_docs.is_collapsed
+                and newer_docs.is_collapsed
+            ):
+                break
+
+        assert screen.expanded_paths == frozenset()
+        assert older_docs is not None
+        assert newer_docs is not None
+        assert older_docs.is_collapsed is True
+        assert newer_docs.is_collapsed is True
 
 
 async def test_archive_compare_screen_updates_selected_path_details(archive_compare_app: BorgBoiApp) -> None:

--- a/tests/tui/archive_compare_screen_test.py
+++ b/tests/tui/archive_compare_screen_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -10,7 +11,7 @@ from borgboi.clients.borg import DiffResult, RepoArchive, RepoInfo
 from borgboi.config import Config
 from borgboi.core.models import Repository
 from borgboi.tui.app import BorgBoiApp
-from borgboi.tui.archive_compare_screen import ArchiveCompareScreen, build_compare_path_states
+from borgboi.tui.archive_compare_screen import ArchiveCompareScreen, CompareDirectoryTree, build_compare_path_states
 from borgboi.tui.repo_info_screen import RepoInfoScreen
 
 
@@ -23,6 +24,7 @@ def archive_compare_result() -> DiffResult:
             "entries": [
                 {"path": "added.txt", "changes": [{"type": "added", "size": 42}]},
                 {"path": "removed.txt", "changes": [{"type": "removed", "size": 11}]},
+                {"path": "only-older/file.txt", "changes": [{"type": "removed", "size": 7}]},
                 {"path": "docs/file.txt", "changes": [{"type": "modified", "added": 12, "removed": 4}]},
                 {
                     "path": "docs/mode.txt",
@@ -121,6 +123,95 @@ async def test_archive_compare_screen_builds_changed_path_trees(archive_compare_
         assert "Changed paths" in str(cast(Any, summary).content)
         assert "2026-03-27_22:00:00" in str(cast(Any, summary).content)
         assert "2026-03-28_22:00:00" in str(cast(Any, summary).content)
+
+
+async def test_archive_compare_screen_mirrors_directory_expansion_when_path_exists(
+    archive_compare_app: BorgBoiApp,
+) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+
+        older_tree = screen.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        newer_tree = screen.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
+        older_docs = await older_tree.find_node_by_relative_path(Path("docs"))
+        newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+
+        assert older_docs is not None
+        assert newer_docs is not None
+        assert older_docs.is_collapsed is True
+        assert newer_docs.is_collapsed is True
+
+        older_docs.expand()
+
+        for _ in range(40):
+            await pilot.pause(0.05)
+            newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+            if newer_docs is not None and newer_docs.is_expanded:
+                break
+
+        assert older_docs.is_expanded is True
+        assert newer_docs is not None
+        assert newer_docs.is_expanded is True
+
+
+async def test_archive_compare_screen_mirrors_directory_collapse_when_path_exists(
+    archive_compare_app: BorgBoiApp,
+) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+
+        older_tree = screen.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        newer_tree = screen.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
+        older_docs = await older_tree.find_node_by_relative_path(Path("docs"))
+        newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+
+        assert older_docs is not None
+        assert newer_docs is not None
+
+        older_docs.expand()
+
+        for _ in range(40):
+            await pilot.pause(0.05)
+            newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+            if newer_docs is not None and newer_docs.is_expanded:
+                break
+
+        assert newer_docs is not None
+        assert older_docs.is_expanded is True
+        assert newer_docs.is_expanded is True
+
+        older_docs.collapse()
+
+        for _ in range(40):
+            await pilot.pause(0.05)
+            newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+            if newer_docs is not None and newer_docs.is_collapsed:
+                break
+
+        assert older_docs.is_collapsed is True
+        assert newer_docs is not None
+        assert newer_docs.is_collapsed is True
+
+
+async def test_archive_compare_screen_ignores_missing_matching_directory(archive_compare_app: BorgBoiApp) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+
+        older_tree = screen.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        newer_tree = screen.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
+        older_only = await older_tree.find_node_by_relative_path(Path("only-older"))
+
+        assert older_only is not None
+        assert older_only.allow_expand is True
+        assert await newer_tree.find_node_by_relative_path(Path("only-older")) is None
+
+        older_only.expand()
+
+        for _ in range(10):
+            await pilot.pause(0.05)
+
+        assert older_only.is_expanded is True
+        assert await newer_tree.find_node_by_relative_path(Path("only-older")) is None
 
 
 async def test_archive_compare_screen_updates_selected_path_details(archive_compare_app: BorgBoiApp) -> None:

--- a/tests/tui/archive_compare_screen_test.py
+++ b/tests/tui/archive_compare_screen_test.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from rich.style import Style
 from textual.widgets import DirectoryTree, Select, Static, Switch
 
 from borgboi.clients.borg import DiffResult, RepoArchive, RepoInfo
@@ -16,6 +17,8 @@ from borgboi.tui.archive_compare_screen import (
     CompareDirectoryTree,
     build_compare_path_states,
     build_compare_tree_highlights,
+    build_compare_tree_modified_paths,
+    build_compare_tree_parent_indicators,
 )
 from borgboi.tui.repo_info_screen import RepoInfoScreen
 
@@ -94,32 +97,68 @@ def test_build_compare_tree_highlights_assigns_side_specific_file_and_directory_
 
     assert older_highlights[Path("removed.txt")] == "red"
     assert Path("added.txt") not in older_highlights
-    assert older_highlights[Path("docs/file.txt")] == "green"
-    assert older_highlights[Path("docs")] == "green"
-    assert older_highlights[Path("only-older")] == "red"
+    assert Path("docs/file.txt") not in older_highlights
+    assert Path("docs/mode.txt") not in older_highlights
+    assert Path("docs") not in older_highlights
+    assert Path("only-older") not in older_highlights
 
     assert newer_highlights[Path("added.txt")] == "green"
     assert Path("removed.txt") not in newer_highlights
-    assert newer_highlights[Path("docs/file.txt")] == "green"
-    assert newer_highlights[Path("docs")] == "green"
+    assert Path("docs/file.txt") not in newer_highlights
+    assert Path("docs/mode.txt") not in newer_highlights
+    assert Path("docs") not in newer_highlights
 
 
-def test_build_compare_tree_highlights_prefers_green_for_mixed_directories() -> None:
+def test_build_compare_tree_modified_paths_marks_direct_modified_files_and_directories() -> None:
     result = DiffResult.model_validate(
         {
             "archive1": "older",
             "archive2": "newer",
             "entries": [
-                {"path": "docs/removed.txt", "changes": [{"type": "removed", "size": 1}]},
-                {"path": "docs/updated.txt", "changes": [{"type": "modified", "added": 2, "removed": 1}]},
+                {"path": "docs/file.txt", "changes": [{"type": "modified", "added": 2, "removed": 1}]},
+                {
+                    "path": "docs/mode.txt",
+                    "changes": [{"type": "mode", "old_mode": "-rw-r--r--", "new_mode": "-rwxr-xr-x"}],
+                },
+                {"path": "direct-dir", "changes": [{"type": "modified", "added": 1, "removed": 0}]},
+                {"path": "added-dir", "changes": [{"type": "added", "size": 1}]},
             ],
         }
     )
 
-    older_highlights, newer_highlights = build_compare_tree_highlights(build_compare_path_states(result))
+    older_modified, newer_modified = build_compare_tree_modified_paths(build_compare_path_states(result))
 
-    assert older_highlights[Path("docs")] == "green"
-    assert newer_highlights[Path("docs")] == "green"
+    assert Path("docs/file.txt") in older_modified
+    assert Path("docs/file.txt") in newer_modified
+    assert Path("docs/mode.txt") in older_modified
+    assert Path("docs/mode.txt") in newer_modified
+    assert Path("direct-dir") in older_modified
+    assert Path("direct-dir") in newer_modified
+    assert Path("added-dir") not in older_modified
+    assert Path("added-dir") not in newer_modified
+
+
+def test_build_compare_tree_parent_indicators_marks_ancestor_only_directories() -> None:
+    result = DiffResult.model_validate(
+        {
+            "archive1": "older",
+            "archive2": "newer",
+            "entries": [
+                {"path": "docs/subdir/removed.txt", "changes": [{"type": "removed", "size": 1}]},
+                {"path": "docs/subdir/updated.txt", "changes": [{"type": "modified", "added": 2, "removed": 1}]},
+                {"path": "direct-dir", "changes": [{"type": "removed", "size": 1}]},
+            ],
+        }
+    )
+
+    older_indicators, newer_indicators = build_compare_tree_parent_indicators(build_compare_path_states(result))
+
+    assert Path("docs") in older_indicators
+    assert Path("docs/subdir") in older_indicators
+    assert Path("docs") in newer_indicators
+    assert Path("docs/subdir") in newer_indicators
+    assert Path("direct-dir") not in older_indicators
+    assert Path("direct-dir") not in newer_indicators
 
 
 async def _open_archive_compare_screen(app: BorgBoiApp, pilot: Any) -> ArchiveCompareScreen:
@@ -176,18 +215,44 @@ async def test_archive_compare_screen_assigns_row_highlights_to_tree_nodes(archi
 
         older_removed = await older_tree.find_node_by_relative_path(Path("removed.txt"))
         older_only_directory = await older_tree.find_node_by_relative_path(Path("only-older"))
+        assert older_only_directory is not None
+        older_only_directory.expand()
+        await pilot.pause()
+        older_only_file = await older_tree.find_node_by_relative_path(Path("only-older/file.txt"))
         newer_added = await newer_tree.find_node_by_relative_path(Path("added.txt"))
         older_docs = await older_tree.find_node_by_relative_path(Path("docs"))
+        newer_docs = await newer_tree.find_node_by_relative_path(Path("docs"))
+
+        assert older_docs is not None
+        older_docs.expand()
+        await pilot.pause()
+        older_modified_file = await older_tree.find_node_by_relative_path(Path("docs/file.txt"))
+        newer_modified_file = await newer_tree.find_node_by_relative_path(Path("docs/file.txt"))
 
         assert older_removed is not None
-        assert older_only_directory is not None
+        assert older_only_file is not None
         assert newer_added is not None
         assert older_docs is not None
+        assert newer_docs is not None
+        assert older_modified_file is not None
+        assert newer_modified_file is not None
 
         assert older_tree._highlight_for_node(older_removed) == "red"
-        assert older_tree._highlight_for_node(older_only_directory) == "red"
+        assert older_tree._highlight_for_node(older_only_directory) is None
+        assert older_tree._highlight_for_node(older_only_file) == "red"
         assert newer_tree._highlight_for_node(newer_added) == "green"
-        assert older_tree._highlight_for_node(older_docs) == "green"
+        assert older_tree._highlight_for_node(older_docs) is None
+        assert older_tree._highlight_for_node(older_modified_file) is None
+        assert newer_tree._highlight_for_node(newer_modified_file) is None
+
+        older_docs_label = older_tree.render_label(older_docs, Style(), Style())
+        older_only_directory_label = older_tree.render_label(older_only_directory, Style(), Style())
+        older_modified_file_label = older_tree.render_label(older_modified_file, Style(), Style())
+        newer_modified_file_label = newer_tree.render_label(newer_modified_file, Style(), Style())
+        assert "(modified)" in older_docs_label.plain
+        assert "(modified)" in older_only_directory_label.plain
+        assert "(modified)" in older_modified_file_label.plain
+        assert "(modified)" in newer_modified_file_label.plain
 
         red_bg = CompareDirectoryTree.ROW_HIGHLIGHT_STYLES["red"].bgcolor
         green_bg = CompareDirectoryTree.ROW_HIGHLIGHT_STYLES["green"].bgcolor
@@ -195,10 +260,16 @@ async def test_archive_compare_screen_assigns_row_highlights_to_tree_nodes(archi
         assert green_bg is not None
 
         older_removed_strip = older_tree.render_line(older_removed.line)
+        older_only_directory_strip = older_tree.render_line(older_only_directory.line)
+        older_modified_file_strip = older_tree.render_line(older_modified_file.line)
         newer_added_strip = newer_tree.render_line(newer_added.line)
+        newer_modified_file_strip = newer_tree.render_line(newer_modified_file.line)
 
         assert any(style is not None and style.bgcolor == red_bg for _, style, _ in older_removed_strip)
+        assert all(style is None or style.bgcolor != red_bg for _, style, _ in older_only_directory_strip)
         assert any(style is not None and style.bgcolor == green_bg for _, style, _ in newer_added_strip)
+        assert all(style is None or style.bgcolor != green_bg for _, style, _ in older_modified_file_strip)
+        assert all(style is None or style.bgcolor != green_bg for _, style, _ in newer_modified_file_strip)
 
 
 async def test_archive_compare_screen_mirrors_directory_expansion_when_path_exists(

--- a/tests/tui/archive_compare_screen_test.py
+++ b/tests/tui/archive_compare_screen_test.py
@@ -11,7 +11,12 @@ from borgboi.clients.borg import DiffResult, RepoArchive, RepoInfo
 from borgboi.config import Config
 from borgboi.core.models import Repository
 from borgboi.tui.app import BorgBoiApp
-from borgboi.tui.archive_compare_screen import ArchiveCompareScreen, CompareDirectoryTree, build_compare_path_states
+from borgboi.tui.archive_compare_screen import (
+    ArchiveCompareScreen,
+    CompareDirectoryTree,
+    build_compare_path_states,
+    build_compare_tree_highlights,
+)
 from borgboi.tui.repo_info_screen import RepoInfoScreen
 
 
@@ -80,6 +85,43 @@ def test_build_compare_path_states_assigns_archive_side_presence(archive_compare
     assert states[cast(Any, next(path for path in states if path.as_posix() == "docs/file.txt"))].newer_exists is True
 
 
+def test_build_compare_tree_highlights_assigns_side_specific_file_and_directory_colors(
+    archive_compare_result: DiffResult,
+) -> None:
+    states = build_compare_path_states(archive_compare_result)
+
+    older_highlights, newer_highlights = build_compare_tree_highlights(states)
+
+    assert older_highlights[Path("removed.txt")] == "red"
+    assert Path("added.txt") not in older_highlights
+    assert older_highlights[Path("docs/file.txt")] == "green"
+    assert older_highlights[Path("docs")] == "green"
+    assert older_highlights[Path("only-older")] == "red"
+
+    assert newer_highlights[Path("added.txt")] == "green"
+    assert Path("removed.txt") not in newer_highlights
+    assert newer_highlights[Path("docs/file.txt")] == "green"
+    assert newer_highlights[Path("docs")] == "green"
+
+
+def test_build_compare_tree_highlights_prefers_green_for_mixed_directories() -> None:
+    result = DiffResult.model_validate(
+        {
+            "archive1": "older",
+            "archive2": "newer",
+            "entries": [
+                {"path": "docs/removed.txt", "changes": [{"type": "removed", "size": 1}]},
+                {"path": "docs/updated.txt", "changes": [{"type": "modified", "added": 2, "removed": 1}]},
+            ],
+        }
+    )
+
+    older_highlights, newer_highlights = build_compare_tree_highlights(build_compare_path_states(result))
+
+    assert older_highlights[Path("docs")] == "green"
+    assert newer_highlights[Path("docs")] == "green"
+
+
 async def _open_archive_compare_screen(app: BorgBoiApp, pilot: Any) -> ArchiveCompareScreen:
     await pilot.pause()
     await pilot.press("i")
@@ -123,6 +165,40 @@ async def test_archive_compare_screen_builds_changed_path_trees(archive_compare_
         assert "Changed paths" in str(cast(Any, summary).content)
         assert "2026-03-27_22:00:00" in str(cast(Any, summary).content)
         assert "2026-03-28_22:00:00" in str(cast(Any, summary).content)
+
+
+async def test_archive_compare_screen_assigns_row_highlights_to_tree_nodes(archive_compare_app: BorgBoiApp) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+
+        older_tree = screen.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        newer_tree = screen.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
+
+        older_removed = await older_tree.find_node_by_relative_path(Path("removed.txt"))
+        older_only_directory = await older_tree.find_node_by_relative_path(Path("only-older"))
+        newer_added = await newer_tree.find_node_by_relative_path(Path("added.txt"))
+        older_docs = await older_tree.find_node_by_relative_path(Path("docs"))
+
+        assert older_removed is not None
+        assert older_only_directory is not None
+        assert newer_added is not None
+        assert older_docs is not None
+
+        assert older_tree._highlight_for_node(older_removed) == "red"
+        assert older_tree._highlight_for_node(older_only_directory) == "red"
+        assert newer_tree._highlight_for_node(newer_added) == "green"
+        assert older_tree._highlight_for_node(older_docs) == "green"
+
+        red_bg = CompareDirectoryTree.ROW_HIGHLIGHT_STYLES["red"].bgcolor
+        green_bg = CompareDirectoryTree.ROW_HIGHLIGHT_STYLES["green"].bgcolor
+        assert red_bg is not None
+        assert green_bg is not None
+
+        older_removed_strip = older_tree.render_line(older_removed.line)
+        newer_added_strip = newer_tree.render_line(newer_added.line)
+
+        assert any(style is not None and style.bgcolor == red_bg for _, style, _ in older_removed_strip)
+        assert any(style is not None and style.bgcolor == green_bg for _, style, _ in newer_added_strip)
 
 
 async def test_archive_compare_screen_mirrors_directory_expansion_when_path_exists(

--- a/tests/tui/archive_compare_screen_test.py
+++ b/tests/tui/archive_compare_screen_test.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from textual.widgets import DirectoryTree, Select, Static, Switch
+
+from borgboi.clients.borg import DiffResult, RepoArchive, RepoInfo
+from borgboi.config import Config
+from borgboi.core.models import Repository
+from borgboi.tui.app import BorgBoiApp
+from borgboi.tui.archive_compare_screen import ArchiveCompareScreen, build_compare_path_states
+from borgboi.tui.repo_info_screen import RepoInfoScreen
+
+
+@pytest.fixture
+def archive_compare_result() -> DiffResult:
+    return DiffResult.model_validate(
+        {
+            "archive1": "2026-03-27_22:00:00",
+            "archive2": "2026-03-28_22:00:00",
+            "entries": [
+                {"path": "added.txt", "changes": [{"type": "added", "size": 42}]},
+                {"path": "removed.txt", "changes": [{"type": "removed", "size": 11}]},
+                {"path": "docs/file.txt", "changes": [{"type": "modified", "added": 12, "removed": 4}]},
+                {
+                    "path": "docs/mode.txt",
+                    "changes": [{"type": "mode", "old_mode": "-rw-r--r--", "new_mode": "-rwxr-xr-x"}],
+                },
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def archive_compare_app(
+    monkeypatch: pytest.MonkeyPatch,
+    tui_config_with_excludes: Config,
+    repo_detail_repo: Repository,
+    live_repo_info: RepoInfo,
+    repo_archives: list[RepoArchive],
+    archive_compare_result: DiffResult,
+) -> BorgBoiApp:
+    monkeypatch.setattr("borgboi.tui.repo_workspace.socket.gethostname", lambda: repo_detail_repo.hostname)
+    repo_detail_repo.path = tui_config_with_excludes.borgboi_dir.as_posix()
+
+    return BorgBoiApp(
+        config=tui_config_with_excludes,
+        orchestrator=cast(
+            Any,
+            SimpleNamespace(
+                config=tui_config_with_excludes,
+                list_repos=lambda: [repo_detail_repo],
+                get_repo_info=lambda _repo: live_repo_info,
+                list_archives=lambda _repo: repo_archives,
+                get_two_most_recent_archives=lambda _repo: (repo_archives[1], repo_archives[0]),
+                diff_archives=lambda _repo, archive1, archive2, options=None, **_: archive_compare_result,
+                get_repo_storage_quota=lambda _repo: "100G",
+                update_repo_storage_quota=lambda quota, **_: quota.upper(),
+                update_repo_config=lambda **kwargs: (
+                    None if kwargs.get("storage_quota") == "" else kwargs.get("storage_quota", "100G"),
+                    kwargs.get("retention_policy", repo_detail_repo.retention_policy),
+                ),
+            ),
+        ),
+    )
+
+
+def test_build_compare_path_states_assigns_archive_side_presence(archive_compare_result: DiffResult) -> None:
+    states = build_compare_path_states(archive_compare_result)
+
+    assert states[cast(Any, next(path for path in states if path.as_posix() == "added.txt"))].older_exists is False
+    assert states[cast(Any, next(path for path in states if path.as_posix() == "added.txt"))].newer_exists is True
+    assert states[cast(Any, next(path for path in states if path.as_posix() == "removed.txt"))].older_exists is True
+    assert states[cast(Any, next(path for path in states if path.as_posix() == "removed.txt"))].newer_exists is False
+    assert states[cast(Any, next(path for path in states if path.as_posix() == "docs/file.txt"))].older_exists is True
+    assert states[cast(Any, next(path for path in states if path.as_posix() == "docs/file.txt"))].newer_exists is True
+
+
+async def _open_archive_compare_screen(app: BorgBoiApp, pilot: Any) -> ArchiveCompareScreen:
+    await pilot.pause()
+    await pilot.press("i")
+    await pilot.pause()
+    assert isinstance(app.screen, RepoInfoScreen)
+    await pilot.press("d")
+
+    for _ in range(60):
+        await pilot.pause(0.05)
+        if isinstance(app.screen, ArchiveCompareScreen) and app.screen._path_states:
+            break
+
+    assert isinstance(app.screen, ArchiveCompareScreen)
+    return app.screen
+
+
+async def test_archive_compare_screen_builds_changed_path_trees(archive_compare_app: BorgBoiApp) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+
+        older_tree = screen.query_one("#archive-compare-older-tree", DirectoryTree)
+        newer_tree = screen.query_one("#archive-compare-newer-tree", DirectoryTree)
+        summary = screen.query_one("#archive-compare-summary", Static)
+        older_select = screen.query_one("#archive-compare-older-select", Select)
+        newer_select = screen.query_one("#archive-compare-newer-select", Select)
+        content_only = screen.query_one("#archive-compare-content-only-switch", Switch)
+
+        assert screen._compare_temp_root.exists() is True
+        assert older_tree.path == screen._older_root
+        assert newer_tree.path == screen._newer_root
+        assert older_select.value == "2026-03-27_22:00:00"
+        assert newer_select.value == "2026-03-28_22:00:00"
+        assert content_only.value is False
+
+        assert (screen._older_root / "removed.txt").exists() is True
+        assert (screen._newer_root / "removed.txt").exists() is False
+        assert (screen._older_root / "added.txt").exists() is False
+        assert (screen._newer_root / "added.txt").exists() is True
+        assert (screen._older_root / "docs" / "file.txt").exists() is True
+        assert (screen._newer_root / "docs" / "file.txt").exists() is True
+        assert "Changed paths" in str(cast(Any, summary).content)
+        assert "2026-03-27_22:00:00" in str(cast(Any, summary).content)
+        assert "2026-03-28_22:00:00" in str(cast(Any, summary).content)
+
+
+async def test_archive_compare_screen_updates_selected_path_details(archive_compare_app: BorgBoiApp) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+
+        screen._show_selected_path(screen._newer_root / "docs" / "file.txt")
+        await pilot.pause()
+
+        selection = screen.query_one("#archive-compare-selection", Static)
+        assert "docs/file.txt" in str(cast(Any, selection).content)
+        assert "modified" in str(cast(Any, selection).content)
+        assert "Older" in str(cast(Any, selection).content)
+        assert "Newer" in str(cast(Any, selection).content)
+
+
+async def test_archive_compare_screen_cleans_up_tempdir_on_dismiss(archive_compare_app: BorgBoiApp) -> None:
+    async with archive_compare_app.run_test() as pilot:
+        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
+        temp_root = screen._compare_temp_root
+
+        assert temp_root.exists() is True
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert temp_root.exists() is False

--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -37,15 +37,24 @@ class FakeBorg:
 
     def create(self, repo_path: str, backup_target: str, **_kwargs: Any) -> Generator[str]:
         self.create_calls.append(f"{repo_path}:{backup_target}")
-        yield '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"create","msgid":"archive.create"}\n'
+        yield (
+            '{"type":"log_message","name":"borg.output.info","levelname":"INFO",'
+            '"message":"create","msgid":"archive.create","time":"2026-01-01T00:00:00"}\n'
+        )
 
     def prune(self, repo_path: str, **_kwargs: Any) -> Generator[str]:
         self.prune_calls.append(repo_path)
-        yield '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"prune","msgid":"archive.prune"}\n'
+        yield (
+            '{"type":"log_message","name":"borg.output.info","levelname":"INFO",'
+            '"message":"prune","msgid":"archive.prune","time":"2026-01-01T00:00:00"}\n'
+        )
 
     def compact(self, repo_path: str, **_kwargs: Any) -> Generator[str]:
         self.compact_calls.append(repo_path)
-        yield '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"compact","msgid":"archive.compact"}\n'
+        yield (
+            '{"type":"log_message","name":"borg.output.info","levelname":"INFO",'
+            '"message":"compact","msgid":"archive.compact","time":"2026-01-01T00:00:00"}\n'
+        )
 
     def info(self, repo_path: str, **_kwargs: Any) -> dict[str, str]:
         return {"repository": repo_path}

--- a/tests/tui/daily_backup_screen_test.py
+++ b/tests/tui/daily_backup_screen_test.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import threading
-import time
 from collections.abc import Generator
 from types import SimpleNamespace
 from typing import Any, cast, override
@@ -67,7 +66,12 @@ async def _open_daily_backup_screen(app: BorgBoiApp, pilot: Any) -> DailyBackupS
     await pilot.press("b")
     await pilot.pause()
     assert isinstance(app.screen, DailyBackupScreen)
-    await pilot.pause()  # let repos load via worker
+    # Wait for repo loading to complete via worker
+    select = app.screen.query_one("#daily-backup-select", Select)
+    for _ in range(50):
+        await pilot.pause(0.05)
+        if not select.loading:
+            break
     return app.screen
 
 
@@ -146,9 +150,15 @@ async def test_backup_failed_shows_error_and_reenables_controls(tui_config_with_
         select = screen.query_one("#daily-backup-select", Select)
         select.value = repo.name
         await pilot.click("#daily-backup-start")
-        await pilot.pause()
 
-        assert screen.query_one("#daily-backup-start", Button).disabled is False
+        # Wait for backup to complete and controls to be re-enabled
+        start_button = screen.query_one("#daily-backup-start", Button)
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if not start_button.disabled:
+                break
+
+        assert start_button.disabled is False
         assert screen.query_one("#daily-backup-select", Select).disabled is False
 
 
@@ -216,7 +226,12 @@ async def test_progress_bar_remains_visible_after_backup_completes(tui_config_wi
         select = screen.query_one("#daily-backup-select", Select)
         select.value = repo.name
         await pilot.click("#daily-backup-start")
-        await pilot.pause()
+
+        # Wait for backup completion
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if not screen._backup_running:
+                break
 
         progress_bar = screen.query_one("#daily-backup-progress", ProgressBar)
         assert progress_bar.display is True
@@ -238,7 +253,12 @@ async def test_progress_bar_remains_visible_after_backup_fails(tui_config_with_e
         select = screen.query_one("#daily-backup-select", Select)
         select.value = repo.name
         await pilot.click("#daily-backup-start")
-        await pilot.pause()
+
+        # Wait for backup to complete (failure)
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if not screen._backup_running:
+                break
 
         progress_bar = screen.query_one("#daily-backup-progress", ProgressBar)
         assert progress_bar.display is True
@@ -268,6 +288,9 @@ async def test_clear_log_resets_progress_bar_state(tui_config_with_excludes: Con
 async def test_progress_bar_stays_visible_until_streaming_create_finishes(tui_config_with_excludes: Config) -> None:
     repo = build_repo("alpha")
 
+    streaming_started = threading.Event()
+    streaming_continue = threading.Event()
+
     class _StreamingBorg(FakeBorg):
         @override
         def create(self, repo_path: str, backup_target: str, **_kwargs: Any) -> Generator[str]:
@@ -276,7 +299,8 @@ async def test_progress_bar_stays_visible_until_streaming_create_finishes(tui_co
                 '{"type":"archive_progress","finished":false,"path":"/some/file.txt","time":"2026-01-01T00:00:00"}\n'
             )
             yield '{"type":"archive_progress","finished":true,"time":"2026-01-01T00:00:00"}\n'
-            time.sleep(0.5)
+            streaming_started.set()
+            streaming_continue.wait(timeout=5)
             yield (
                 '{"type":"log_message","name":"borg.output.stats","levelname":"INFO",'
                 '"message":"Repository: /repo","time":"2026-01-01T00:00:00"}\n'
@@ -290,12 +314,23 @@ async def test_progress_bar_stays_visible_until_streaming_create_finishes(tui_co
         select = screen.query_one("#daily-backup-select", Select)
         select.value = repo.name
         await pilot.click("#daily-backup-start")
-        await pilot.pause(0.2)
+
+        # Wait until streaming has started but hasn't finished
+        assert streaming_started.wait(timeout=5) is True
+        await pilot.pause(0.05)
 
         progress_bar = screen.query_one("#daily-backup-progress", ProgressBar)
         assert progress_bar.display is True
 
-        await pilot.pause(0.5)
+        # Let streaming complete
+        streaming_continue.set()
+
+        # Wait for backup to complete
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if not screen._backup_running:
+                break
+
         assert progress_bar.display is True
 
 
@@ -419,11 +454,17 @@ async def test_daily_backup_progress_advances_during_prune_without_percent_outpu
 
         # Wait until the prune step has actually started in the worker thread
         prune_entered.wait(timeout=5)
-        await pilot.pause(0.15)
 
         progress_bar = screen.query_one("#daily-backup-progress", ProgressBar)
         create_boundary = (1_000.0 / 2_200.0) * 100.0
         prune_boundary = ((1_000.0 + 200.0) / 2_200.0) * 100.0
+
+        # Poll until progress advances into the prune range
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if create_boundary < progress_bar.progress < prune_boundary:
+                break
+
         assert create_boundary < progress_bar.progress < prune_boundary
 
         prune_continue.set()

--- a/tests/tui/daily_backup_screen_test.py
+++ b/tests/tui/daily_backup_screen_test.py
@@ -22,6 +22,11 @@ from .conftest import FakeBorg, FakeStorage, build_repo
 class _ProgressBorg(FakeBorg):
     """FakeBorg that yields a 50% progress event during create, then sleeps."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.create_progress_reported = threading.Event()
+        self.allow_create_finish = threading.Event()
+
     @override
     def create(self, repo_path: str, backup_target: str, **_kwargs: Any) -> Generator[str]:
         self.create_calls.append(f"{repo_path}:{backup_target}")
@@ -29,7 +34,8 @@ class _ProgressBorg(FakeBorg):
             '{"type":"progress_percent","operation":0,"msgid":"archive.create",'
             '"finished":false,"current":50,"total":100,"time":"2026-01-01T00:00:00"}\n'
         )
-        time.sleep(0.4)
+        self.create_progress_reported.set()
+        self.allow_create_finish.wait(timeout=5)
 
 
 def _build_daily_backup_app(
@@ -304,7 +310,8 @@ async def test_daily_backup_progress_uses_default_duration_weighting_when_s3_syn
 
     repo = build_repo("alpha")
 
-    app, _, _ = _build_daily_backup_app(config, [repo], borg=_ProgressBorg(), s3=MockS3Client())
+    borg = _ProgressBorg()
+    app, _, _ = _build_daily_backup_app(config, [repo], borg=borg, s3=MockS3Client())
 
     async with app.run_test() as pilot:
         screen = await _open_daily_backup_screen(app, pilot)
@@ -313,7 +320,9 @@ async def test_daily_backup_progress_uses_default_duration_weighting_when_s3_syn
         select.value = repo.name
         screen.query_one("#daily-backup-s3-switch", Switch).value = False
         await pilot.click("#daily-backup-start")
-        await pilot.pause(0.2)
+
+        borg.create_progress_reported.wait(timeout=5)
+        await pilot.pause(0.05)
 
         progress_bar = screen.query_one("#daily-backup-progress", ProgressBar)
         expected_create_span = (
@@ -325,6 +334,8 @@ async def test_daily_backup_progress_uses_default_duration_weighting_when_s3_syn
             )
         ) * 100.0
         assert progress_bar.progress == pytest.approx(expected_create_span / 2.0)
+
+        borg.allow_create_finish.set()
 
 
 async def test_daily_backup_progress_uses_default_duration_weighting_when_s3_sync_enabled(
@@ -338,7 +349,8 @@ async def test_daily_backup_progress_uses_default_duration_weighting_when_s3_syn
 
     repo = build_repo("alpha")
 
-    app, _, _ = _build_daily_backup_app(config, [repo], borg=_ProgressBorg(), s3=MockS3Client())
+    borg = _ProgressBorg()
+    app, _, _ = _build_daily_backup_app(config, [repo], borg=borg, s3=MockS3Client())
 
     async with app.run_test() as pilot:
         screen = await _open_daily_backup_screen(app, pilot)
@@ -346,7 +358,9 @@ async def test_daily_backup_progress_uses_default_duration_weighting_when_s3_syn
         select = screen.query_one("#daily-backup-select", Select)
         select.value = repo.name
         await pilot.click("#daily-backup-start")
-        await pilot.pause(0.2)
+
+        borg.create_progress_reported.wait(timeout=5)
+        await pilot.pause(0.05)
 
         progress_bar = screen.query_one("#daily-backup-progress", ProgressBar)
         expected_create_span = (
@@ -359,6 +373,8 @@ async def test_daily_backup_progress_uses_default_duration_weighting_when_s3_syn
             )
         ) * 100.0
         assert progress_bar.progress == pytest.approx(expected_create_span / 2.0)
+
+        borg.allow_create_finish.set()
 
 
 async def test_daily_backup_progress_advances_during_prune_without_percent_output(

--- a/tests/tui/repo_config_screen_test.py
+++ b/tests/tui/repo_config_screen_test.py
@@ -67,13 +67,22 @@ async def test_repo_config_screen_disables_quota_after_load_failure(
         await app.push_screen(
             RepoConfigScreen(repo=repo_detail_repo, orchestrator=app.orchestrator, config=tui_config_with_excludes)
         )
-        await pilot.pause(0.2)
+        await pilot.pause()
 
         assert isinstance(app.screen, RepoConfigScreen)
 
+        # Wait for quota load failure to be applied
         quota_input = app.screen.query_one("#repo-config-quota-input", Input)
         daily_input = app.screen.query_one("#repo-config-daily-input", Input)
         current = app.screen.query_one("#repo-config-current", Static)
+
+        import asyncio
+
+        for _ in range(50):
+            if quota_input.disabled and "Unavailable" in str(cast(Any, current).content):
+                break
+            await asyncio.sleep(0.05)
+
         assert quota_input.disabled is True
         assert daily_input.disabled is False
         assert "Unavailable" in str(cast(Any, current).content)

--- a/tests/tui/repo_info_screen_test.py
+++ b/tests/tui/repo_info_screen_test.py
@@ -11,6 +11,7 @@ from borgboi.clients.borg import RepoArchive, RepoInfo
 from borgboi.config import Config
 from borgboi.core.models import Repository, RetentionPolicy
 from borgboi.tui.app import BorgBoiApp
+from borgboi.tui.archive_compare_screen import ArchiveCompareScreen
 from borgboi.tui.repo_config_screen import RepoConfigScreen
 from borgboi.tui.repo_info_screen import RepoInfoScreen, load_repo_excludes_state
 
@@ -331,6 +332,7 @@ async def test_repo_info_screen_hides_workspace_tree_for_remote_repo(
         quota_summary = repo_info_app.screen.query_one("#repo-info-config", Static)
         storage_card = repo_info_app.screen.query_one("#repo-info-storage-card", Static)
         edit_button = repo_info_app.screen.query_one("#repo-info-edit-config-btn", Button)
+        compare_button = repo_info_app.screen.query_one("#repo-info-compare-archives-btn", Button)
 
         assert "Workspace tree unavailable" in str(cast(Any, workspace_status).content)
         assert "only available for repositories on this machine" in str(cast(Any, workspace_unavailable).content)
@@ -340,7 +342,33 @@ async def test_repo_info_screen_hides_workspace_tree_for_remote_repo(
         assert "Unavailable" in str(cast(Any, quota_summary).content)
         assert "Quota Unknown" in str(cast(Any, storage_card).content)
         assert edit_button.disabled is False
+        assert compare_button.disabled is True
         assert len(repo_info_app.screen.query("#repo-info-workspace-tree")) == 0
+
+
+async def test_repo_info_screen_opens_archive_compare_screen(
+    monkeypatch: pytest.MonkeyPatch,
+    repo_info_app: BorgBoiApp,
+    repo_detail_repo: Repository,
+    tmp_path: Any,
+) -> None:
+    repo_detail_repo.path = tmp_path.as_posix()
+    monkeypatch.setattr("borgboi.tui.repo_workspace.socket.gethostname", lambda: repo_detail_repo.hostname)
+
+    async with repo_info_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("i")
+        await pilot.pause()
+
+        assert isinstance(repo_info_app.screen, RepoInfoScreen)
+
+        await pilot.press("d")
+        for _ in range(60):
+            await pilot.pause(0.05)
+            if isinstance(repo_info_app.screen, ArchiveCompareScreen):
+                break
+
+        assert isinstance(repo_info_app.screen, ArchiveCompareScreen)
 
 
 async def test_repo_info_screen_opens_repo_config_screen(

--- a/tests/tui/repo_info_screen_test.py
+++ b/tests/tui/repo_info_screen_test.py
@@ -176,15 +176,35 @@ async def test_repo_info_screen_handles_unreadable_excludes_file(
     repo_specific_path.write_bytes(b"\xff\xfe")
 
     async with repo_info_app.run_test() as pilot:
-        await pilot.pause()
+        # Wait for main screen repos to load
+        table = repo_info_app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if table.row_count > 0:
+                break
         await pilot.press("i")
-        await pilot.pause()
+
+        # Wait for RepoInfoScreen to be active
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if isinstance(repo_info_app.screen, RepoInfoScreen):
+                break
 
         assert isinstance(repo_info_app.screen, RepoInfoScreen)
 
         excludes_status = repo_info_app.screen.query_one("#repo-info-excludes-status", Static)
         excludes_viewer = repo_info_app.screen.query_one("#repo-info-excludes-viewer", TextArea)
         command_output = repo_info_app.screen.query_one("#repo-info-command-output", Static)
+
+        # Wait for worker results
+        import asyncio
+
+        for _ in range(50):
+            if "could not be read" in str(cast(Any, excludes_status).content) and "Deduplicated Size" in str(
+                cast(Any, command_output).content
+            ):
+                break
+            await asyncio.sleep(0.05)
 
         assert "could not be read" in str(cast(Any, excludes_status).content)
         assert excludes_viewer.text == ""
@@ -193,9 +213,19 @@ async def test_repo_info_screen_handles_unreadable_excludes_file(
 
 async def test_repo_info_screen_handles_live_load_errors(repo_info_error_app: BorgBoiApp) -> None:
     async with repo_info_error_app.run_test() as pilot:
-        await pilot.pause()
+        # Wait for main screen repos to load
+        table = repo_info_error_app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if table.row_count > 0:
+                break
         await pilot.press("i")
-        await pilot.pause()
+
+        # Wait for RepoInfoScreen to be active
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if isinstance(repo_info_error_app.screen, RepoInfoScreen):
+                break
 
         assert isinstance(repo_info_error_app.screen, RepoInfoScreen)
 
@@ -203,6 +233,18 @@ async def test_repo_info_screen_handles_live_load_errors(repo_info_error_app: Bo
         command_output = repo_info_error_app.screen.query_one("#repo-info-command-output", Static)
         archives_status = repo_info_error_app.screen.query_one("#repo-info-archives-status", Static)
         archives_table = repo_info_error_app.screen.query_one("#repo-info-archives-table", DataTable)
+
+        # Wait for worker error results
+        import asyncio
+
+        for _ in range(50):
+            if (
+                "Failed to load live repository data." in str(cast(Any, loading).content)
+                and "borg unavailable" in str(cast(Any, command_output).content)
+                and "Archive list unavailable." in str(cast(Any, archives_status).content)
+            ):
+                break
+            await asyncio.sleep(0.05)
 
         assert str(cast(Any, loading).content) == "Failed to load live repository data."
         assert "borg unavailable" in str(cast(Any, command_output).content)

--- a/tests/tui/repo_info_screen_test.py
+++ b/tests/tui/repo_info_screen_test.py
@@ -371,6 +371,24 @@ async def test_repo_info_screen_opens_archive_compare_screen(
         assert isinstance(repo_info_app.screen, ArchiveCompareScreen)
 
 
+async def test_repo_info_screen_shortcut_opens_archives_tab_and_focuses_table(repo_info_app: BorgBoiApp) -> None:
+    async with repo_info_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("i")
+        await pilot.pause()
+
+        assert isinstance(repo_info_app.screen, RepoInfoScreen)
+
+        tabs = repo_info_app.screen.query_one("#repo-info-tabs", TabbedContent)
+        archives_table = repo_info_app.screen.query_one("#repo-info-archives-table", DataTable)
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        assert tabs.active == "repo-info-archives-tab"
+        assert repo_info_app.focused is archives_table
+
+
 async def test_repo_info_screen_opens_repo_config_screen(
     monkeypatch: pytest.MonkeyPatch,
     repo_info_app: BorgBoiApp,

--- a/tests/tui/tui_output_handler_test.py
+++ b/tests/tui/tui_output_handler_test.py
@@ -234,7 +234,10 @@ def test_on_stderr_skips_empty_lines() -> None:
 
 def test_on_stderr_parses_log_message_json() -> None:
     handler, written = _make_handler()
-    log_line = '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"archive created","msgid":"archive.create"}'
+    log_line = (
+        '{"type":"log_message","name":"borg.output.info","levelname":"INFO",'
+        '"message":"archive created","msgid":"archive.create","time":"2026-01-01T00:00:00"}'
+    )
 
     handler.on_stderr(log_line)
 
@@ -276,7 +279,7 @@ def test_on_stats_formats_key_value_pairs() -> None:
 def test_render_command_writes_header_body_and_footer() -> None:
     handler, written = _make_handler()
     log_lines = [
-        '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"pruning","msgid":"archive.prune"}\n',
+        '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"pruning","msgid":"archive.prune","time":"2026-01-01T00:00:00"}\n',
     ]
 
     handler.render_command("Pruning", "Prune complete", log_lines)
@@ -322,7 +325,7 @@ def test_handler_without_progress_bar_does_not_fail() -> None:
 def test_render_command_resets_progress_before_streaming() -> None:
     handler, _, progress_bar, cft_calls = _make_handler_with_progress()
     log_lines = [
-        '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"working","msgid":"test"}\n',
+        '{"type":"log_message","name":"borg.output.info","levelname":"INFO","message":"working","msgid":"test","time":"2026-01-01T00:00:00"}\n',
     ]
 
     handler.render_command("Creating", "Create done", log_lines)


### PR DESCRIPTION
This pull request introduces a new shared module for formatting and summarizing archive diff results, refactors related CLI and test code to use it, and adds UI enhancements for archive comparison in the TUI. It also includes dependency and workflow updates, a bugfix changelog entry, and minor code improvements.

**Archive Diff Utilities Refactor:**
- Added a new module `src/borgboi/lib/diff.py` with `summarize_diff_changes` and `format_diff_change` helpers, consolidating and documenting logic for summarizing and rendering archive diffs.
- Refactored `src/borgboi/cli/backup.py` and `tests/backup_cli_test.py` to use the new shared helpers, removing duplicate implementations and updating imports and test cases accordingly. [[1]](diffhunk://#diff-f367a16f0120d0fd8048bb26d47f1e25a2e08efb5a11349b6dc38b56da573a44R12-R18) [[2]](diffhunk://#diff-f367a16f0120d0fd8048bb26d47f1e25a2e08efb5a11349b6dc38b56da573a44L80-L134) [[3]](diffhunk://#diff-f367a16f0120d0fd8048bb26d47f1e25a2e08efb5a11349b6dc38b56da573a44L152-R102) [[4]](diffhunk://#diff-657f4e35bb40593d8a679d0acacd1b4078b07db8be40195cb0994ba69dbd3523L11-R15) [[5]](diffhunk://#diff-657f4e35bb40593d8a679d0acacd1b4078b07db8be40195cb0994ba69dbd3523L280-R279) [[6]](diffhunk://#diff-657f4e35bb40593d8a679d0acacd1b4078b07db8be40195cb0994ba69dbd3523L300-R299) [[7]](diffhunk://#diff-657f4e35bb40593d8a679d0acacd1b4078b07db8be40195cb0994ba69dbd3523L310-R309) [[8]](diffhunk://#diff-657f4e35bb40593d8a679d0acacd1b4078b07db8be40195cb0994ba69dbd3523L330-R329)

**TUI Archive Comparison Feature:**
- Enhanced the repository info screen (`src/borgboi/tui/repo_info_screen.py`) with a "Compare archives" button, keyboard shortcut, and related actions, including logic to enable/disable the button and select default archives for comparison. (Fc599c55L20R20, [[1]](diffhunk://#diff-51a0591cb01c59a5665c9429421941a474a5a3e1c95e4ca8aa825b3ef47222a6R238-R244) [[2]](diffhunk://#diff-51a0591cb01c59a5665c9429421941a474a5a3e1c95e4ca8aa825b3ef47222a6R313-R340) [[3]](diffhunk://#diff-51a0591cb01c59a5665c9429421941a474a5a3e1c95e4ca8aa825b3ef47222a6L414-R455) [[4]](diffhunk://#diff-51a0591cb01c59a5665c9429421941a474a5a3e1c95e4ca8aa825b3ef47222a6R691-R697) [[5]](diffhunk://#diff-51a0591cb01c59a5665c9429421941a474a5a3e1c95e4ca8aa825b3ef47222a6R706-R718) [[6]](diffhunk://#diff-51a0591cb01c59a5665c9429421941a474a5a3e1c95e4ca8aa825b3ef47222a6R734)
- Added corresponding styles for the archive compare UI in `src/borgboi/tui/borgboi.tcss`.

**Dependency and Workflow Updates:**
- Updated the `uv` dependency version in GitHub workflows to `0.11.3` for improved dependency management. [[1]](diffhunk://#diff-5f52eaedfd785b5c9a77a6b1ad06a20e0e854e3ac2db7f63bd0946062df8b855L28-R28) [[2]](diffhunk://#diff-72cdf96df6105ec84b17990be2044085291b26ed252559687d4ea6246a6703afL35-R35) [[3]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL29-R29)
- Bumped the `anthropics/claude-code-action` action version in workflows for code review and Claude integration. [[1]](diffhunk://#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30L36-R36) [[2]](diffhunk://#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342eL35-R35)
- Updated project version to `1.26.1` and added a bugfix changelog entry. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R7)

**Other Improvements:**
- Improved issue linking in changelog rendering by adding a postprocessor to `cliff.toml`.