### PR TITLE
feat(tui): add decorator-based span capture

### DIFF
--- a/src/borgboi/tui/app.py
+++ b/src/borgboi/tui/app.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager, nullcontext
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, ClassVar, cast, override
+from typing import TYPE_CHECKING, ClassVar, override
 
-from opentelemetry.trace import INVALID_SPAN as _NOOP_SPAN
-from opentelemetry.trace import Span
+from opentelemetry import trace
 from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
@@ -15,7 +13,7 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import DataTable, Footer, Header, Sparkline, Static
 
 from borgboi.core.logging import get_logger
-from borgboi.core.telemetry import get_tracer, set_span_attributes
+from borgboi.core.telemetry import set_span_attributes
 from borgboi.lib.utils import format_last_backup, format_repo_size
 from borgboi.storage.db import get_db_path
 from borgboi.tui.config_screen import ConfigScreen
@@ -23,9 +21,9 @@ from borgboi.tui.daily_backup_progress import SQLiteDailyBackupProgressHistory
 from borgboi.tui.daily_backup_screen import DailyBackupScreen
 from borgboi.tui.excludes_screen import DefaultExcludesScreen
 from borgboi.tui.repo_info_screen import RepoInfoScreen
+from borgboi.tui.telemetry import capture_span
 
 logger = get_logger(__name__)
-tracer = get_tracer(__name__)
 
 if TYPE_CHECKING:
     from textual.screen import Screen
@@ -63,11 +61,6 @@ class BorgBoiApp(App[None]):
         self._repos: list[BorgBoiRepo] = []
         self._repos_table: DataTable[str] | None = None
 
-    def _span(self, name: str) -> AbstractContextManager[Span]:
-        if self._config is None or not self._config.telemetry.capture_tui:
-            return cast("AbstractContextManager[Span]", nullcontext(cast("Span", _NOOP_SPAN)))
-        return tracer.start_as_current_span(name)
-
     @property
     def orchestrator(self) -> Orchestrator:
         """Return the shared orchestrator, constructing it lazily if not provided at init."""
@@ -94,51 +87,51 @@ class BorgBoiApp(App[None]):
                     yield Static("", classes="sparkline-x-label", id=f"sparkline-x-label-{index}")
         yield Footer()
 
+    @capture_span("tui.app.mount")
     def on_mount(self) -> None:
         """Initialise the repos table columns and trigger the initial data load."""
-        with self._span("tui.app.mount") as span:
-            set_span_attributes(
-                span,
-                {
-                    "borgboi.mode.offline": self._config.offline if self._config else None,
-                    "borgboi.ui.theme": self._config.ui.theme if self._config else None,
-                },
-            )
-            logger.info("TUI app mounted", offline=self._config.offline if self._config else None)
-            self._main_screen = self.screen
+        set_span_attributes(
+            trace.get_current_span(),
+            {
+                "borgboi.mode.offline": self._config.offline if self._config else None,
+                "borgboi.ui.theme": self._config.ui.theme if self._config else None,
+            },
+        )
+        logger.info("TUI app mounted", offline=self._config.offline if self._config else None)
+        self._main_screen = self.screen
 
-            # Mode indicator in header subtitle
-            if self._config is not None:
-                self.sub_title = "Offline" if self._config.offline else "Online"
+        # Mode indicator in header subtitle
+        if self._config is not None:
+            self.sub_title = "Offline" if self._config.offline else "Online"
 
-            # Titled borders for dashboard sections
-            repos_section = self.query_one("#repos-section", Vertical)
-            repos_section.border_title = "Repositories"
+        # Titled borders for dashboard sections
+        repos_section = self.query_one("#repos-section", Vertical)
+        repos_section.border_title = "Repositories"
 
-            sparkline_section = self.query_one("#sparkline-section", Vertical)
-            sparkline_section.border_title = "Archive Activity"
-            sparkline_section.border_subtitle = "Last 2 Weeks"
+        sparkline_section = self.query_one("#sparkline-section", Vertical)
+        sparkline_section.border_title = "Archive Activity"
+        sparkline_section.border_subtitle = "Last 2 Weeks"
 
-            # Simplified repo table
-            self._repos_table = table = self.query_one("#repos-table", DataTable)
-            table.cursor_type = "row"
-            table.add_columns("Name", "Hostname", "Last Archive", "Size")
-            table.loading = True
-            self._load_repos()
-            self._load_sparkline_data()
+        # Simplified repo table
+        self._repos_table = table = self.query_one("#repos-table", DataTable)
+        table.cursor_type = "row"
+        table.add_columns("Name", "Hostname", "Last Archive", "Size")
+        table.loading = True
+        self._load_repos()
+        self._load_sparkline_data()
 
     @work(thread=True, exclusive=True)
+    @capture_span("tui.load_repos")
     def _load_repos(self) -> None:
-        with self._span("tui.load_repos") as span:
-            logger.debug("Loading repositories for TUI dashboard")
-            try:
-                repos = self.orchestrator.list_repos()
-                span.set_attribute("borgboi.repo.count", len(repos))
-                logger.info("Repositories loaded", count=len(repos))
-                self.call_from_thread(self._populate_table, repos)
-            except Exception as e:
-                logger.exception("Failed to load repositories", error=str(e))
-                self.call_from_thread(self._on_load_error, e)
+        logger.debug("Loading repositories for TUI dashboard")
+        try:
+            repos = self.orchestrator.list_repos()
+            trace.get_current_span().set_attribute("borgboi.repo.count", len(repos))
+            logger.info("Repositories loaded", count=len(repos))
+            self.call_from_thread(self._populate_table, repos)
+        except Exception as e:
+            logger.exception("Failed to load repositories", error=str(e))
+            self.call_from_thread(self._on_load_error, e)
 
     def _populate_table(self, repos: list[BorgBoiRepo]) -> None:
         self._repos = repos
@@ -179,23 +172,21 @@ class BorgBoiApp(App[None]):
         return self._repos[row_index]
 
     @work(thread=True, exclusive=True, group="sparkline")
+    @capture_span("tui.load_sparkline")
     def _load_sparkline_data(self) -> None:
-        with self._span("tui.load_sparkline") as span:
-            logger.debug("Loading sparkline data")
-            try:
-                today = datetime.now(UTC).date()
-                with SQLiteDailyBackupProgressHistory(
-                    db_path=get_db_path(self._config.borgboi_dir if self._config else None)
-                ) as history:
-                    data = history.get_daily_archive_counts(SPARKLINE_DAYS)
-                labels = [
-                    (today - timedelta(days=SPARKLINE_DAYS - 1 - i)).strftime("%m/%d") for i in range(SPARKLINE_DAYS)
-                ]
-                span.set_attribute("borgboi.sparkline.points", len(data))
-                logger.debug("Sparkline data loaded", data_points=len(data))
-                self.call_from_thread(self._update_sparkline, data, labels)
-            except Exception:
-                logger.debug("Failed to load sparkline data", exc_info=True)
+        logger.debug("Loading sparkline data")
+        try:
+            today = datetime.now(UTC).date()
+            with SQLiteDailyBackupProgressHistory(
+                db_path=get_db_path(self._config.borgboi_dir if self._config else None)
+            ) as history:
+                data = history.get_daily_archive_counts(SPARKLINE_DAYS)
+            labels = [(today - timedelta(days=SPARKLINE_DAYS - 1 - i)).strftime("%m/%d") for i in range(SPARKLINE_DAYS)]
+            trace.get_current_span().set_attribute("borgboi.sparkline.points", len(data))
+            logger.debug("Sparkline data loaded", data_points=len(data))
+            self.call_from_thread(self._update_sparkline, data, labels)
+        except Exception:
+            logger.debug("Failed to load sparkline data", exc_info=True)
 
     def _update_sparkline(self, data: list[float], labels: list[str]) -> None:
         self.query_one("#archive-sparkline", Sparkline).data = data

--- a/src/borgboi/tui/telemetry.py
+++ b/src/borgboi/tui/telemetry.py
@@ -1,0 +1,73 @@
+"""Telemetry helpers for TUI method instrumentation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from functools import wraps
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+
+from opentelemetry.trace import INVALID_SPAN as _NOOP_SPAN
+from opentelemetry.trace import Span, use_span
+
+from borgboi.core.telemetry import get_tracer
+
+if TYPE_CHECKING:
+    from borgboi.config import Config
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+tracer = get_tracer(__name__)
+
+
+def _resolve_config(instance: object) -> Config | None:
+    direct_config = getattr(instance, "_config", None)
+    if direct_config is not None:
+        return cast("Config", direct_config)
+
+    orchestrator = getattr(instance, "_orchestrator", None)
+    orchestrator_config = getattr(orchestrator, "config", None)
+    if orchestrator_config is not None:
+        return cast("Config", orchestrator_config)
+
+    app = getattr(instance, "app", None)
+    app_config = getattr(app, "_config", None)
+    if app_config is not None:
+        return cast("Config", app_config)
+
+    return None
+
+
+def _span_context(instance: object, name: str) -> AbstractContextManager[Span]:
+    config = _resolve_config(instance)
+    if config is None or not config.telemetry.capture_tui:
+        return cast("AbstractContextManager[Span]", use_span(_NOOP_SPAN, end_on_exit=False))
+    return tracer.start_as_current_span(name)
+
+
+def capture_span(name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Capture a TUI span around the decorated method when enabled."""
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                instance = args[0] if args else None
+                with _span_context(instance, name):
+                    result = await cast("Callable[P, Any]", func)(*args, **kwargs)
+                    return cast("R", result)
+
+            return cast("Callable[P, R]", async_wrapper)
+
+        @wraps(func)
+        def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            instance = args[0] if args else None
+            with _span_context(instance, name):
+                return func(*args, **kwargs)
+
+        return cast("Callable[P, R]", sync_wrapper)
+
+    return decorator

--- a/tests/tui/app_test.py
+++ b/tests/tui/app_test.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
+import pytest
 from textual.widgets import DataTable, Static
 
-from borgboi.config import Config
+from borgboi.config import Config, TelemetryConfig
 from borgboi.models import BorgBoiRepo
 from borgboi.storage.db import get_db_path
 from borgboi.tui.app import BorgBoiApp
@@ -15,7 +16,7 @@ from borgboi.tui.daily_backup_screen import DailyBackupScreen
 from borgboi.tui.excludes_screen import DefaultExcludesScreen
 from borgboi.tui.repo_info_screen import RepoInfoScreen
 
-from .conftest import build_repo
+from .conftest import FakeTracer, build_repo, make_orchestrator
 
 
 async def test_app_composes_with_data_table_and_sections(tui_app: BorgBoiApp) -> None:
@@ -27,7 +28,7 @@ async def test_app_composes_with_data_table_and_sections(tui_app: BorgBoiApp) ->
 
 async def test_app_loads_and_populates_repos_table(tui_config: Config) -> None:
     repos = [build_repo("alpha"), build_repo("beta")]
-    orchestrator = cast(Any, SimpleNamespace(list_repos=lambda: repos))
+    orchestrator = make_orchestrator(list_repos=lambda: repos)
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
@@ -61,16 +62,7 @@ async def test_action_show_config_ignored_on_non_main_screen(tui_app: BorgBoiApp
 
 
 async def test_action_daily_backup_pushes_screen(tui_config: Config) -> None:
-    orchestrator = cast(
-        Any,
-        SimpleNamespace(
-            config=tui_config,
-            borg=None,
-            storage=None,
-            s3=None,
-            list_repos=lambda: [build_repo("alpha")],
-        ),
-    )
+    orchestrator = make_orchestrator(config=tui_config, list_repos=lambda: [build_repo("alpha")])
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
@@ -80,17 +72,11 @@ async def test_action_daily_backup_pushes_screen(tui_config: Config) -> None:
 
 
 async def test_action_show_repo_info_pushes_screen(tui_config: Config, repo_with_live_metadata: BorgBoiRepo) -> None:
-    orchestrator = cast(
-        Any,
-        SimpleNamespace(
-            config=tui_config,
-            borg=None,
-            storage=None,
-            s3=None,
-            list_repos=lambda: [repo_with_live_metadata],
-            get_repo_info=lambda _repo: repo_with_live_metadata.metadata,
-            list_archives=lambda _repo: [],
-        ),
+    orchestrator = make_orchestrator(
+        config=tui_config,
+        list_repos=lambda: [repo_with_live_metadata],
+        get_repo_info=lambda _repo: repo_with_live_metadata.metadata,
+        list_archives=lambda _repo: [],
     )
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
@@ -109,17 +95,11 @@ async def test_action_show_repo_info_pushes_screen(tui_config: Config, repo_with
 async def test_repo_table_row_selected_opens_repo_info_screen(
     tui_config: Config, repo_with_live_metadata: BorgBoiRepo
 ) -> None:
-    orchestrator = cast(
-        Any,
-        SimpleNamespace(
-            config=tui_config,
-            borg=None,
-            storage=None,
-            s3=None,
-            list_repos=lambda: [repo_with_live_metadata],
-            get_repo_info=lambda _repo: repo_with_live_metadata.metadata,
-            list_archives=lambda _repo: [],
-        ),
+    orchestrator = make_orchestrator(
+        config=tui_config,
+        list_repos=lambda: [repo_with_live_metadata],
+        get_repo_info=lambda _repo: repo_with_live_metadata.metadata,
+        list_archives=lambda _repo: [],
     )
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
@@ -135,17 +115,10 @@ async def test_repo_table_row_selected_opens_repo_info_screen(
         assert isinstance(app.screen, RepoInfoScreen)
 
 
-async def test_returning_from_successful_backup_refreshes_dashboard(tui_config: Config, monkeypatch: Any) -> None:
-    orchestrator = cast(
-        Any,
-        SimpleNamespace(
-            config=tui_config,
-            borg=None,
-            storage=None,
-            s3=None,
-            list_repos=lambda: [build_repo("alpha")],
-        ),
-    )
+async def test_returning_from_successful_backup_refreshes_dashboard(
+    tui_config: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    orchestrator = make_orchestrator(config=tui_config, list_repos=lambda: [build_repo("alpha")])
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     repo_refreshes = 0
@@ -191,17 +164,11 @@ async def test_action_daily_backup_ignored_on_non_main_screen(tui_app: BorgBoiAp
 async def test_action_show_repo_info_ignored_on_non_main_screen(
     tui_config: Config, repo_with_live_metadata: BorgBoiRepo
 ) -> None:
-    orchestrator = cast(
-        Any,
-        SimpleNamespace(
-            config=tui_config,
-            borg=None,
-            storage=None,
-            s3=None,
-            list_repos=lambda: [repo_with_live_metadata],
-            get_repo_info=lambda _repo: repo_with_live_metadata.metadata,
-            list_archives=lambda _repo: [],
-        ),
+    orchestrator = make_orchestrator(
+        config=tui_config,
+        list_repos=lambda: [repo_with_live_metadata],
+        get_repo_info=lambda _repo: repo_with_live_metadata.metadata,
+        list_archives=lambda _repo: [],
     )
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
@@ -221,7 +188,7 @@ async def test_action_refresh_reloads_repos(tui_config: Config) -> None:
         call_count += 1
         return [build_repo("alpha")]
 
-    orchestrator = cast(Any, SimpleNamespace(list_repos=counting_list_repos))
+    orchestrator = make_orchestrator(list_repos=counting_list_repos)
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
@@ -243,29 +210,18 @@ async def test_action_refresh_reloads_repos(tui_config: Config) -> None:
 
 
 async def test_app_loads_sparkline_history_from_configured_db(
-    tui_config: Config, monkeypatch: Any, tmp_path_factory: Any
+    tui_config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+    patch_sparkline_history: Callable[..., None],
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     captured_db_paths: list[object] = []
     alternate_home = tmp_path_factory.mktemp("alt-home")
 
-    class FakeHistory:
-        def __init__(self, db_path: object = None, engine: object = None) -> None:
-            del engine
-            captured_db_paths.append(db_path)
-
-        def __enter__(self) -> FakeHistory:
-            return self
-
-        def __exit__(self, *exc: object) -> None:
-            return None
-
-        def get_daily_archive_counts(self, days: int) -> list[float]:
-            return [0.0] * days
-
-    orchestrator = cast(Any, SimpleNamespace(list_repos=lambda: [build_repo("alpha")]))
+    orchestrator = make_orchestrator(list_repos=lambda: [build_repo("alpha")])
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
     monkeypatch.setenv("BORGBOI_HOME", alternate_home.as_posix())
-    monkeypatch.setattr("borgboi.tui.app.SQLiteDailyBackupProgressHistory", FakeHistory)
+    patch_sparkline_history([0.0] * 14, captured_db_paths)
 
     today = datetime.now(UTC).date()
     expected_labels = [(today - timedelta(days=13 - index)).strftime("%m/%d") for index in range(14)]
@@ -287,7 +243,7 @@ async def test_load_repos_error_shows_notification(tui_config: Config) -> None:
     def failing_list_repos() -> list[BorgBoiRepo]:
         raise RuntimeError("db down")
 
-    orchestrator = cast(Any, SimpleNamespace(list_repos=failing_list_repos))
+    orchestrator = make_orchestrator(list_repos=failing_list_repos)
     app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
 
     async with app.run_test() as pilot:
@@ -299,3 +255,50 @@ async def test_load_repos_error_shows_notification(tui_config: Config) -> None:
                 break
         assert table.loading is False
         assert table.row_count == 0
+
+
+async def test_app_captures_expected_tui_spans(
+    fake_tui_tracer: FakeTracer,
+    patch_sparkline_history: Callable[..., None],
+    tui_config: Config,
+) -> None:
+    orchestrator = make_orchestrator(list_repos=lambda: [build_repo("alpha")])
+    app = BorgBoiApp(config=tui_config, orchestrator=orchestrator)
+    patch_sparkline_history([1.0] * 14)
+
+    async with app.run_test() as pilot:
+        table = app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            label = app.query_one("#sparkline-x-label-0", Static)
+            if not table.loading and label.content:
+                break
+
+    assert fake_tui_tracer.started_spans[0] == "tui.app.mount"
+    assert set(fake_tui_tracer.started_spans[1:]) == {"tui.load_repos", "tui.load_sparkline"}
+
+
+async def test_app_skips_tui_spans_when_capture_disabled(
+    fake_tui_tracer: FakeTracer,
+    monkeypatch: pytest.MonkeyPatch,
+    patch_sparkline_history: Callable[..., None],
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("BORGBOI_HOME", tmp_path.as_posix())
+
+    config = Config(offline=True, telemetry=TelemetryConfig(capture_tui=False))
+    config.borgboi_dir.mkdir(parents=True, exist_ok=True)
+
+    orchestrator = make_orchestrator(list_repos=lambda: [build_repo("alpha")])
+    app = BorgBoiApp(config=config, orchestrator=orchestrator)
+    patch_sparkline_history([1.0] * 14)
+
+    async with app.run_test() as pilot:
+        table = app.query_one("#repos-table", DataTable)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            label = app.query_one("#sparkline-x-label-0", Static)
+            if not table.loading and label.content:
+                break
+
+    assert fake_tui_tracer.started_spans == []

--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -68,6 +68,75 @@ class FakeStorage:
 
     def save(self, repo: BorgBoiRepo) -> None:
         self.saved_repos.append(repo.name)
+
+
+class FakeSpan:
+    def set_attribute(self, _key: str, _value: object) -> None:
+        pass
+
+
+class FakeSpanContext:
+    def __init__(self, recorder: list[str], name: str) -> None:
+        self._recorder = recorder
+        self._name = name
+
+    def __enter__(self) -> FakeSpan:
+        self._recorder.append(self._name)
+        return FakeSpan()
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        del exc_type, exc, tb
+
+
+class FakeTracer:
+    def __init__(self) -> None:
+        self.started_spans: list[str] = []
+
+    def start_as_current_span(self, name: str) -> FakeSpanContext:
+        return FakeSpanContext(self.started_spans, name)
+
+
+def make_orchestrator(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "config": None,
+        "borg": None,
+        "storage": None,
+        "s3": None,
+    }
+    defaults.update(overrides)
+    return cast(Any, SimpleNamespace(**defaults))
+
+
+@pytest.fixture
+def fake_tui_tracer(monkeypatch: pytest.MonkeyPatch) -> FakeTracer:
+    tracer = FakeTracer()
+    monkeypatch.setattr("borgboi.tui.telemetry.tracer", tracer)
+    return tracer
+
+
+@pytest.fixture
+def patch_sparkline_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[..., None]:
+    def patch(data: list[float], captured_db_paths: list[object] | None = None) -> None:
+        class FakeHistory:
+            def __init__(self, db_path: object = None, engine: object = None) -> None:
+                del engine
+                if captured_db_paths is not None:
+                    captured_db_paths.append(db_path)
+
+            def __enter__(self) -> FakeHistory:
+                return self
+
+            def __exit__(self, *exc: object) -> None:
+                return None
+
+            def get_daily_archive_counts(self, days: int) -> list[float]:
+                return data[:days] if len(data) >= days else [*data, *([0.0] * (days - len(data)))]
+
+        monkeypatch.setattr("borgboi.tui.app.SQLiteDailyBackupProgressHistory", FakeHistory)
+
+    return patch
 
 
 @pytest.fixture

--- a/tests/tui/telemetry_test.py
+++ b/tests/tui/telemetry_test.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState, use_span
+
+from borgboi.config import Config, TelemetryConfig
+from borgboi.tui.telemetry import capture_span
+
+from .conftest import FakeTracer
+
+
+class _ConfigMethodHost:
+    def __init__(self, config: Config | None) -> None:
+        self._config = config
+
+    @capture_span("tui.test.sync")
+    def run(self, value: str) -> str:
+        return value.upper()
+
+    @capture_span("tui.test.explode")
+    def explode(self) -> None:
+        raise RuntimeError("boom")
+
+    @capture_span("tui.test.current-span")
+    def current_span_is_valid(self) -> bool:
+        return trace.get_current_span().get_span_context().is_valid
+
+
+class _AsyncConfigMethodHost:
+    def __init__(self, config: Config | None) -> None:
+        self._config = config
+
+    @capture_span("tui.test.async")
+    async def run(self, value: str) -> str:
+        return value.upper()
+
+
+class _OrchestratorMethodHost:
+    def __init__(self, config: Config) -> None:
+        self._orchestrator = SimpleNamespace(config=config)
+
+    @capture_span("tui.test.orchestrator")
+    def run(self) -> str:
+        return "ok"
+
+
+class _AppMethodHost:
+    def __init__(self, config: Config) -> None:
+        self.app = SimpleNamespace(_config=config)
+
+    @capture_span("tui.test.app")
+    def run(self) -> str:
+        return "ok"
+
+
+def test_capture_span_wraps_sync_methods(fake_tui_tracer: FakeTracer) -> None:
+    host = _ConfigMethodHost(Config(telemetry=TelemetryConfig(capture_tui=True)))
+
+    assert host.run("alpha") == "ALPHA"
+    assert fake_tui_tracer.started_spans == ["tui.test.sync"]
+    assert host.run.__name__ == "run"
+    assert cast("Any", host.run).__wrapped__.__name__ == "run"
+
+
+@pytest.mark.asyncio
+async def test_capture_span_wraps_async_methods(fake_tui_tracer: FakeTracer) -> None:
+    host = _AsyncConfigMethodHost(Config(telemetry=TelemetryConfig(capture_tui=True)))
+
+    assert await host.run("beta") == "BETA"
+    assert fake_tui_tracer.started_spans == ["tui.test.async"]
+
+
+def test_capture_span_uses_orchestrator_config(fake_tui_tracer: FakeTracer) -> None:
+    host = _OrchestratorMethodHost(Config(telemetry=TelemetryConfig(capture_tui=True)))
+
+    assert host.run() == "ok"
+    assert fake_tui_tracer.started_spans == ["tui.test.orchestrator"]
+
+
+def test_capture_span_uses_app_config(fake_tui_tracer: FakeTracer) -> None:
+    host = _AppMethodHost(Config(telemetry=TelemetryConfig(capture_tui=True)))
+
+    assert host.run() == "ok"
+    assert fake_tui_tracer.started_spans == ["tui.test.app"]
+
+
+def test_capture_span_skips_when_tui_capture_disabled(fake_tui_tracer: FakeTracer) -> None:
+    host = _ConfigMethodHost(Config(telemetry=TelemetryConfig(capture_tui=False)))
+
+    assert host.run("gamma") == "GAMMA"
+    assert fake_tui_tracer.started_spans == []
+
+
+def test_capture_span_tolerates_missing_config(fake_tui_tracer: FakeTracer) -> None:
+    host = _ConfigMethodHost(None)
+
+    assert host.run("delta") == "DELTA"
+    assert fake_tui_tracer.started_spans == []
+
+
+def test_capture_span_preserves_exceptions(fake_tui_tracer: FakeTracer) -> None:
+    host = _ConfigMethodHost(Config(telemetry=TelemetryConfig(capture_tui=True)))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        host.explode()
+
+    assert fake_tui_tracer.started_spans == ["tui.test.explode"]
+
+
+def test_capture_span_disabled_blocks_parent_span_leak(fake_tui_tracer: FakeTracer) -> None:
+    host = _ConfigMethodHost(Config(telemetry=TelemetryConfig(capture_tui=False)))
+
+    span_context = SpanContext(
+        trace_id=int("1234" * 8, 16),
+        span_id=int("abcd" * 4, 16),
+        is_remote=False,
+        trace_flags=TraceFlags(0x01),
+        trace_state=TraceState(),
+    )
+
+    with use_span(NonRecordingSpan(span_context), end_on_exit=False):
+        assert host.current_span_is_valid() is False
+
+    assert fake_tui_tracer.started_spans == []


### PR DESCRIPTION
Replace inline TUI span context blocks with a reusable capture_span decorator so app and screen methods can be instrumented consistently. Centralize shared TUI test fixtures to keep telemetry coverage maintainable as the rollout expands.