### PR TITLE
Refactor Archive Tree Comparison and Borg Client

### DIFF
--- a/src/borgboi/cli/backup.py
+++ b/src/borgboi/cli/backup.py
@@ -15,7 +15,7 @@ from borgboi.rich_utils import console
 if TYPE_CHECKING:
     from rich.table import Table
 
-    from borgboi.clients.borg import ArchiveInfo, DiffResult
+    from borgboi.clients.borg_models import ArchiveInfo, DiffResult
 
 
 logger = get_logger(__name__)
@@ -349,7 +349,6 @@ def backup_contents(
     """List contents of an archive."""
     from pathlib import Path
 
-    from borgboi.clients import borg
     from borgboi.lib import utils
     from borgboi.lib.colors import COLOR_HEX
 
@@ -362,7 +361,7 @@ def backup_contents(
     )
     try:
         repo_info = ctx.orchestrator.get_repo(name=name, path=path)
-        contents = borg.list_archive_contents(repo_info.path, archive, passphrase=passphrase)
+        contents = ctx.orchestrator.borg.list_archive_contents(repo_info.path, archive, passphrase=passphrase)
         logger.debug(
             "Retrieved archive contents",
             repo_name=_repo_name(repo_info, name),

--- a/src/borgboi/clients/borg.py
+++ b/src/borgboi/clients/borg.py
@@ -1,18 +1,55 @@
 import subprocess as sp
 from collections.abc import Generator
-from datetime import datetime
-from functools import cached_property
 from pathlib import Path
 
-from pydantic import BaseModel, Field, computed_field
-
+from borgboi.clients.borg_models import (
+    ArchivedFile,
+    ArchiveInfo,
+    ArchiveStats,
+    DiffChange,
+    DiffEntry,
+    DiffResult,
+    Encryption,
+    ListArchivesOutput,
+    RepoArchive,
+    RepoCache,
+    RepoInfo,
+    Repository,
+    Stats,
+)
 from borgboi.config import config
 from borgboi.core.logging import get_logger
 from borgboi.lib.utils import create_archive_name
 
-GIBIBYTES_IN_GIGABYTE = 0.93132257461548
-
 logger = get_logger(__name__)
+
+__all__ = [
+    "ArchiveInfo",
+    "ArchiveStats",
+    "ArchivedFile",
+    "DiffChange",
+    "DiffEntry",
+    "DiffResult",
+    "Encryption",
+    "ListArchivesOutput",
+    "RepoArchive",
+    "RepoCache",
+    "RepoInfo",
+    "Repository",
+    "Stats",
+    "archive_info",
+    "compact",
+    "create_archive",
+    "delete",
+    "delete_archive",
+    "export_repo_key",
+    "extract",
+    "info",
+    "init_repository",
+    "list_archive_contents",
+    "list_archives",
+    "prune",
+]
 
 
 def _build_env_with_passphrase(passphrase: str | None = None) -> dict[str, str] | None:
@@ -159,76 +196,6 @@ def create_archive(
         )
         raise sp.CalledProcessError(returncode=proc.returncode, cmd=cmd)
     logger.info("Borg archive created successfully", repo_path=repo_path, archive_name=archive_name)
-
-
-class Stats(BaseModel):
-    total_chunks: int
-    total_csize: int = Field(description="Compressed size")
-    total_size: int = Field(description="Original size")
-    total_unique_chunks: int
-    unique_csize: int = Field(description="Deduplicated size")
-    unique_size: int
-
-
-class RepoCache(BaseModel):
-    path: str
-    stats: Stats
-
-    @computed_field  # type: ignore[prop-decorator]
-    @cached_property
-    def total_size_gb(self) -> str:
-        """Original size in gigabytes."""
-        return f"{(self.stats.total_size / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE):.2f}"
-
-    @computed_field  # type: ignore[prop-decorator]
-    @cached_property
-    def total_csize_gb(self) -> str:
-        """Compressed size in gigabytes."""
-        return f"{(self.stats.total_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE):.2f}"
-
-    @computed_field  # type: ignore[prop-decorator]
-    @cached_property
-    def unique_csize_gb(self) -> str:
-        """Deduplicated size in gigabytes."""
-        return f"{(self.stats.unique_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE):.2f}"
-
-
-class Encryption(BaseModel):
-    mode: str
-
-
-class Repository(BaseModel):
-    id: str
-    last_modified: str
-    location: str
-
-
-class RepoInfo(BaseModel):
-    cache: RepoCache
-    encryption: Encryption
-    repository: Repository
-    security_dir: str
-    archives: list[dict[str, object]] = []
-
-
-class ArchiveStats(BaseModel):
-    compressed_size: int
-    deduplicated_size: int
-    nfiles: int
-    original_size: int
-
-
-class ArchiveInfo(BaseModel):
-    archives: list[dict[str, object]]
-    cache: RepoCache
-    encryption: Encryption
-    repository: Repository
-
-    @property
-    def archive(self) -> dict[str, object]:
-        if not self.archives:
-            raise ValueError("ArchiveInfo contains no archives.")
-        return self.archives[0]
 
 
 def info(repo_path: str, passphrase: str | None = None) -> RepoInfo:
@@ -578,18 +545,6 @@ def delete_archive(
     logger.info("Borg archive deleted", repo_path=repo_path, archive_name=archive_name, dry_run=dry_run)
 
 
-class RepoArchive(BaseModel):
-    archive: str
-    id: str
-    name: str
-    start: str
-    time: str
-
-
-class ListArchivesOutput(BaseModel):
-    archives: list[RepoArchive]
-
-
 def list_archives(repo_path: str, passphrase: str | None = None) -> list[RepoArchive]:
     """List the archives in a Borg repository."""
     logger.debug("Listing Borg archives", repo_path=repo_path)
@@ -602,42 +557,6 @@ def list_archives(repo_path: str, passphrase: str | None = None) -> list[RepoArc
     list_archives_output = ListArchivesOutput.model_validate_json(result.stdout)
     logger.debug("Listed Borg archives", repo_path=repo_path, archive_count=len(list_archives_output.archives))
     return list_archives_output.archives
-
-
-class ArchivedFile(BaseModel):
-    type: str
-    mode: str
-    user: str
-    group: str
-    uid: int
-    gid: int
-    path: str
-    healthy: bool
-    source: str
-    size: int
-    mtime: datetime
-
-
-class DiffChange(BaseModel):
-    type: str
-    added: int | None = None
-    removed: int | None = None
-    size: int | None = None
-    old: str | int | float | None = None
-    new: str | int | float | None = None
-    old_mode: str | None = None
-    new_mode: str | None = None
-
-
-class DiffEntry(BaseModel):
-    path: Path
-    changes: list[DiffChange] = Field(default_factory=list)
-
-
-class DiffResult(BaseModel):
-    archive1: str
-    archive2: str
-    entries: list[DiffEntry] = Field(default_factory=list)
 
 
 def list_archive_contents(

--- a/src/borgboi/clients/borg_client.py
+++ b/src/borgboi/clients/borg_client.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
 
-from borgboi.clients.borg import (
+from borgboi.clients.borg_models import (
     ArchivedFile,
     ArchiveInfo,
     DiffEntry,

--- a/src/borgboi/clients/borg_models.py
+++ b/src/borgboi/clients/borg_models.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+from functools import cached_property
+from pathlib import Path
+
+from pydantic import BaseModel, Field, computed_field
+
+GIBIBYTES_IN_GIGABYTE = 0.93132257461548
+
+
+class Stats(BaseModel):
+    total_chunks: int
+    total_csize: int = Field(description="Compressed size")
+    total_size: int = Field(description="Original size")
+    total_unique_chunks: int
+    unique_csize: int = Field(description="Deduplicated size")
+    unique_size: int
+
+
+class RepoCache(BaseModel):
+    path: str
+    stats: Stats
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def total_size_gb(self) -> str:
+        """Original size in gigabytes."""
+        return f"{(self.stats.total_size / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE):.2f}"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def total_csize_gb(self) -> str:
+        """Compressed size in gigabytes."""
+        return f"{(self.stats.total_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE):.2f}"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def unique_csize_gb(self) -> str:
+        """Deduplicated size in gigabytes."""
+        return f"{(self.stats.unique_csize / 1024 / 1024 / 1024 / GIBIBYTES_IN_GIGABYTE):.2f}"
+
+
+class Encryption(BaseModel):
+    mode: str
+
+
+class Repository(BaseModel):
+    id: str
+    last_modified: str
+    location: str
+
+
+class RepoInfo(BaseModel):
+    cache: RepoCache
+    encryption: Encryption
+    repository: Repository
+    security_dir: str
+    archives: list[dict[str, object]] = []
+
+
+class ArchiveStats(BaseModel):
+    compressed_size: int
+    deduplicated_size: int
+    nfiles: int
+    original_size: int
+
+
+class ArchiveInfo(BaseModel):
+    archives: list[dict[str, object]]
+    cache: RepoCache
+    encryption: Encryption
+    repository: Repository
+
+    @property
+    def archive(self) -> dict[str, object]:
+        if not self.archives:
+            raise ValueError("ArchiveInfo contains no archives.")
+        return self.archives[0]
+
+
+class RepoArchive(BaseModel):
+    archive: str
+    id: str
+    name: str
+    start: str
+    time: str
+
+
+class ListArchivesOutput(BaseModel):
+    archives: list[RepoArchive]
+
+
+class ArchivedFile(BaseModel):
+    type: str
+    mode: str
+    user: str
+    group: str
+    uid: int
+    gid: int
+    path: str
+    healthy: bool
+    source: str
+    size: int
+    mtime: datetime
+
+
+class DiffChange(BaseModel):
+    type: str
+    added: int | None = None
+    removed: int | None = None
+    size: int | None = None
+    old: str | int | float | None = None
+    new: str | int | float | None = None
+    old_mode: str | None = None
+    new_mode: str | None = None
+
+
+class DiffEntry(BaseModel):
+    path: Path
+    changes: list[DiffChange] = Field(default_factory=list)
+
+
+class DiffResult(BaseModel):
+    archive1: str
+    archive2: str
+    entries: list[DiffEntry] = Field(default_factory=list)

--- a/src/borgboi/clients/dynamodb.py
+++ b/src/borgboi/clients/dynamodb.py
@@ -8,7 +8,7 @@ from botocore.config import Config
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from borgboi import validator
-from borgboi.clients import borg
+from borgboi.clients.borg_client import BorgClient, create_borg_client
 from borgboi.config import config
 from borgboi.core.logging import get_logger
 from borgboi.lib.passphrase import resolve_passphrase
@@ -17,6 +17,10 @@ from borgboi.rich_utils import console
 
 boto_config = Config(retries={"mode": "standard"})
 logger = get_logger(__name__)
+
+
+def _get_borg_client() -> BorgClient:
+    return create_borg_client(silent=True)
 
 
 class BorgBoiArchiveTableItem(BaseModel):
@@ -130,7 +134,7 @@ def _convert_table_item_to_repo(item: BorgBoiRepoTableItem) -> BorgBoiRepo:
             db_passphrase=item.passphrase,
             allow_env_fallback=True,
         )
-        metadata = borg.info(item.repo_path, passphrase=passphrase)
+        metadata = _get_borg_client().info(item.repo_path, passphrase=passphrase)
 
     return BorgBoiRepo(
         path=item.repo_path,
@@ -398,7 +402,7 @@ def build_archive_table_item(
         Populated archive table item ready for DynamoDB
     """
     logger.debug("Building archive table item", repo_name=repo.name, repo_path=repo.path, archive_name=archive_name)
-    archive_info = borg.archive_info(repo.path, archive_name, passphrase)
+    archive_info = _get_borg_client().archive_info(repo.path, archive_name, passphrase)
     archive_data = archive_info.archive
     archive_id = archive_data.get("id")
     hostname = archive_data.get("hostname")

--- a/src/borgboi/core/orchestrator.py
+++ b/src/borgboi/core/orchestrator.py
@@ -14,8 +14,8 @@ from platform import system
 
 from pydantic import ValidationError as PydanticValidationError
 
-from borgboi.clients.borg import DiffResult, RepoArchive, RepoInfo
 from borgboi.clients.borg_client import BorgClient, ExtractedFileContent, create_borg_client
+from borgboi.clients.borg_models import DiffResult, RepoArchive, RepoInfo
 from borgboi.clients.s3_client import S3ClientInterface
 from borgboi.config import Config, get_config
 from borgboi.core.errors import RepositoryNotFoundError, StorageError, ValidationError

--- a/src/borgboi/lib/diff.py
+++ b/src/borgboi/lib/diff.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Literal
 
-from borgboi.clients.borg import DiffChange, DiffEntry, DiffResult
+from borgboi.clients.borg_models import DiffChange, DiffEntry, DiffResult
 from borgboi.lib.utils import format_size_bytes
 
 DiffChangeKind = Literal["added", "removed", "modified", "mode"]

--- a/src/borgboi/lib/utils.py
+++ b/src/borgboi/lib/utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from borgboi.clients.borg import RepoInfo
+    from borgboi.clients.borg_models import RepoInfo
 
 ARCHIVE_NAME_FORMAT = "%Y-%m-%d_%H:%M:%S"
 BACKUP_DATE_FORMAT = "%a %b %d, %Y"

--- a/src/borgboi/models.py
+++ b/src/borgboi/models.py
@@ -11,7 +11,7 @@ from platform import system
 
 from pydantic import BaseModel, Field, computed_field, field_validator
 
-from borgboi.clients.borg import RepoInfo
+from borgboi.clients.borg_models import RepoInfo
 
 # Re-export from core.models for new usage
 from borgboi.core.models import (

--- a/src/borgboi/storage/sqlite.py
+++ b/src/borgboi/storage/sqlite.py
@@ -6,7 +6,7 @@ from typing import override
 
 from sqlalchemy import Engine
 
-from borgboi.clients.borg import RepoInfo
+from borgboi.clients.borg_models import RepoInfo
 from borgboi.core.errors import RepositoryNotFoundError, StorageError
 from borgboi.core.logging import get_logger
 from borgboi.core.models import RetentionPolicy

--- a/src/borgboi/tui/features/archive_compare/__init__.py
+++ b/src/borgboi/tui/features/archive_compare/__init__.py
@@ -4,6 +4,7 @@ from borgboi.tui.features.archive_compare.content_diff_modal import ContentDiffS
 from borgboi.tui.features.archive_compare.screen import (
     ArchiveCompareScreen,
     CompareDirectoryTree,
+    ComparePathIndex,
     ComparePathState,
     build_compare_path_states,
     build_compare_tree_highlights,
@@ -14,6 +15,7 @@ from borgboi.tui.features.archive_compare.screen import (
 __all__ = [
     "ArchiveCompareScreen",
     "CompareDirectoryTree",
+    "ComparePathIndex",
     "ComparePathState",
     "ContentDiffScreen",
     "build_compare_path_states",

--- a/src/borgboi/tui/features/archive_compare/screen.py
+++ b/src/borgboi/tui/features/archive_compare/screen.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
-import shutil
+import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, ClassVar, Literal, override
 
 from rich.markup import escape
 from rich.style import Style
-from rich.text import Text
+from rich.text import Text, TextType
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
@@ -21,7 +20,6 @@ from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import (
     Button,
-    DirectoryTree,
     Footer,
     Header,
     Input,
@@ -31,7 +29,6 @@ from textual.widgets import (
     Switch,
     Tree,
 )
-from textual.widgets.directory_tree import DirEntry
 from textual.widgets.tree import TreeNode
 
 from borgboi.clients.borg import DiffChange, DiffResult, RepoArchive
@@ -63,6 +60,56 @@ class ComparePathState:
     older_exists: bool
     newer_exists: bool
     changes: tuple[DiffChange, ...]
+
+
+@dataclass
+class CompareTreeEntry:
+    """Node metadata for an in-memory archive compare tree."""
+
+    relative_path: Path
+    loaded: bool = False
+
+
+@dataclass(frozen=True)
+class ComparePathIndex:
+    """Side-specific path index used to hydrate compare tree nodes lazily."""
+
+    children: dict[Path, tuple[Path, ...]]
+
+    @classmethod
+    def from_paths(cls, paths: Iterable[Path]) -> ComparePathIndex:
+        child_sets: dict[Path, set[Path]] = {Path(): set()}
+        for path in paths:
+            if not path.parts:
+                continue
+            for part_count in range(1, len(path.parts) + 1):
+                child = Path(*path.parts[:part_count])
+                parent = Path(*path.parts[: part_count - 1])
+                child_sets.setdefault(parent, set()).add(child)
+                child_sets.setdefault(child, set())
+
+        children = {
+            parent: tuple(
+                sorted(child_paths, key=lambda child: (not child_sets[child], child.name.lower(), child.name))
+            )
+            for parent, child_paths in child_sets.items()
+        }
+        return cls(children=children)
+
+    def has_children(self, relative_path: Path) -> bool:
+        """Return whether a path has indexed children."""
+        return bool(self.children.get(relative_path))
+
+    def iter_visible_children(self, relative_path: Path, visible_paths: set[Path] | None) -> Iterable[Path]:
+        """Yield direct children visible under the active filter."""
+        for child in self.children.get(relative_path, ()):
+            if visible_paths is None or self._is_relative_path_visible(child, visible_paths):
+                yield child
+
+    @staticmethod
+    def _is_relative_path_visible(relative_path: Path, visible_paths: set[Path]) -> bool:
+        """Return True if a path is visible or is an ancestor of a visible path."""
+        return relative_path in visible_paths or any(relative_path in target.parents for target in visible_paths)
 
 
 CompareRowHighlight = Literal["green", "red"]
@@ -243,8 +290,8 @@ def _merge_compare_highlight(
     highlights[relative_path] = highlight if highlight == "green" or current is None else current
 
 
-class CompareDirectoryTree(DirectoryTree):
-    """Directory tree with compare-specific helpers and sync messages."""
+class CompareDirectoryTree(Tree[CompareTreeEntry]):
+    """In-memory archive compare tree with lazy child hydration."""
 
     ROW_HIGHLIGHT_STYLES: ClassVar[dict[CompareRowHighlight, Style]] = {
         "green": Style.parse("on #213a2c"),
@@ -267,57 +314,105 @@ class CompareDirectoryTree(DirectoryTree):
             self.path = path
             super().__init__()
 
+    class PathSelected(Message):
+        """Posted when a compare path is selected."""
+
+        def __init__(self, directory_tree: CompareDirectoryTree, path: Path) -> None:
+            self.directory_tree = directory_tree
+            self.path = path
+            super().__init__()
+
     def __init__(
         self,
-        path: str | Path,
+        label: str,
         *,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
         disabled: bool = False,
     ) -> None:
-        super().__init__(path, name=name, id=id, classes=classes, disabled=disabled)
-        self._compare_root_resolved = Path(path).resolve()
+        super().__init__(label, data=CompareTreeEntry(Path()), name=name, id=id, classes=classes, disabled=disabled)
+        self._path_index = ComparePathIndex.from_paths(())
         self._row_highlights: dict[Path, CompareRowHighlight] = {}
         self._modified_paths: set[Path] = set()
         self._modified_parent_paths: set[Path] = set()
         self._visible_paths: set[Path] | None = None
         self._mute_directory_messages: bool = False
+        self.root.expand()
 
-    def on_tree_node_expanded(self, event: Tree.NodeExpanded[DirEntry]) -> None:
+    @override
+    def process_label(self, label: TextType) -> Text:
+        """Process labels as literal path names, not Rich markup."""
+        text_label = Text(label) if isinstance(label, str) else label
+        return text_label
+
+    def set_path_index(self, paths: Iterable[Path]) -> None:
+        """Replace the backing path index and render root-level children."""
+        self._path_index = ComparePathIndex.from_paths(paths)
+        self._visible_paths = None
+        self._reset_tree(expanded_paths=frozenset())
+
+    def _reset_tree(self, *, expanded_paths: frozenset[str]) -> None:
+        """Rebuild visible nodes while preserving requested expanded paths."""
+        self.root.data = CompareTreeEntry(Path())
+        self.root.remove_children()
+        self.root.expand()
+        self._populate_node(self.root)
+        for expanded_path in sorted(expanded_paths, key=lambda item: (len(Path(item).parts), item)):
+            self._expand_relative_path(Path(expanded_path))
+        self.move_cursor(None)
+        self.scroll_to(0, 0, animate=False)
+
+    def on_tree_node_expanded(self, event: Tree.NodeExpanded[CompareTreeEntry]) -> None:
         """Relay directory expansion through a public custom message."""
-        if self._mute_directory_messages:
+        event.stop()
+        entry = event.node.data
+        if entry is None or not event.node.allow_expand:
             return
-        dir_entry = event.node.data
-        if dir_entry is None or not event.node.allow_expand:
-            return
-        self.post_message(self.DirectoryExpanded(self, dir_entry.path))
+        self._ensure_node_loaded_sync(event.node)
+        if not self._mute_directory_messages and entry.relative_path.parts:
+            self.post_message(self.DirectoryExpanded(self, entry.relative_path))
 
-    def on_tree_node_collapsed(self, event: Tree.NodeCollapsed[DirEntry]) -> None:
+    def on_tree_node_collapsed(self, event: Tree.NodeCollapsed[CompareTreeEntry]) -> None:
         """Relay directory collapse through a public custom message."""
-        if self._mute_directory_messages:
+        event.stop()
+        entry = event.node.data
+        if (
+            self._mute_directory_messages
+            or entry is None
+            or not event.node.allow_expand
+            or not entry.relative_path.parts
+        ):
             return
-        dir_entry = event.node.data
-        if dir_entry is None or not event.node.allow_expand:
-            return
-        self.post_message(self.DirectoryCollapsed(self, dir_entry.path))
+        self.post_message(self.DirectoryCollapsed(self, entry.relative_path))
 
-    async def ensure_node_loaded(self, node: TreeNode[DirEntry]) -> None:
+    def on_tree_node_selected(self, event: Tree.NodeSelected[CompareTreeEntry]) -> None:
+        """Publish selected compare paths to the screen."""
+        event.stop()
+        entry = event.node.data
+        if entry is None:
+            return
+        self.post_message(self.PathSelected(self, entry.relative_path))
+
+    async def ensure_node_loaded(self, node: TreeNode[CompareTreeEntry]) -> None:
         """Ensure a directory node's children are loaded using public APIs."""
-        if not node.allow_expand or node.data is None or node.data.loaded:
-            return
-        await self.reload_node(node)
+        self._ensure_node_loaded_sync(node)
 
-    async def find_node_by_relative_path(self, relative_path: Path) -> TreeNode[DirEntry] | None:
+    async def find_node_by_relative_path(self, relative_path: Path) -> TreeNode[CompareTreeEntry] | None:
         """Locate a node by relative path, loading ancestor directories as needed."""
-        current_node = self.root
-        if not relative_path.parts:
-            return current_node
+        return self._find_node_by_relative_path_sync(relative_path)
 
+    def _find_node_by_relative_path_sync(self, relative_path: Path) -> TreeNode[CompareTreeEntry] | None:
+        """Locate a node by relative path synchronously."""
+        current_node = self.root
         for part in relative_path.parts:
-            await self.ensure_node_loaded(current_node)
-            child_node: TreeNode[DirEntry] | None = next(
-                (child for child in current_node.children if child.data is not None and child.data.path.name == part),
+            self._ensure_node_loaded_sync(current_node)
+            child_node: TreeNode[CompareTreeEntry] | None = next(
+                (
+                    child
+                    for child in current_node.children
+                    if child.data is not None and child.data.relative_path.name == part
+                ),
                 None,
             )
             if child_node is None:
@@ -325,6 +420,34 @@ class CompareDirectoryTree(DirectoryTree):
             current_node = child_node
 
         return current_node
+
+    def _expand_relative_path(self, relative_path: Path) -> None:
+        """Expand a path and its ancestors if they are visible."""
+        for part_count in range(1, len(relative_path.parts) + 1):
+            node = self._find_node_by_relative_path_sync(Path(*relative_path.parts[:part_count]))
+            if node is None or not node.allow_expand:
+                return
+            node.expand()
+            self._ensure_node_loaded_sync(node)
+
+    def _ensure_node_loaded_sync(self, node: TreeNode[CompareTreeEntry]) -> None:
+        """Populate children for one indexed directory node if needed."""
+        if not node.allow_expand or node.data is None or node.data.loaded:
+            return
+        self._populate_node(node)
+
+    def _populate_node(self, node: TreeNode[CompareTreeEntry]) -> None:
+        """Populate a tree node from the in-memory index."""
+        if node.data is None:
+            return
+        node.remove_children()
+        for child_path in self._path_index.iter_visible_children(node.data.relative_path, self._visible_paths):
+            node.add(
+                child_path.name,
+                data=CompareTreeEntry(child_path),
+                allow_expand=self._path_index.has_children(child_path),
+            )
+        node.data.loaded = True
 
     def set_compare_overlays(
         self,
@@ -342,35 +465,25 @@ class CompareDirectoryTree(DirectoryTree):
     def set_visible_paths(self, visible_paths: set[Path] | None) -> None:
         """Restrict rendered entries to the given relative paths.
 
-        `None` disables filtering (full materialized mirror shown).
+        `None` disables filtering (all indexed paths shown).
         """
+        expanded_paths = self._expanded_relative_paths()
         self._visible_paths = visible_paths
+        self._reset_tree(expanded_paths=expanded_paths)
+
+    def _expanded_relative_paths(self) -> frozenset[str]:
+        """Return currently expanded non-root paths."""
+        expanded: set[str] = set()
+        nodes = list(self.root.children)
+        while nodes:
+            node = nodes.pop()
+            if node.data is not None and node.allow_expand and node.is_expanded and node.data.relative_path.parts:
+                expanded.add(node.data.relative_path.as_posix())
+            nodes.extend(node.children)
+        return frozenset(expanded)
 
     @override
-    def filter_paths(self, paths: Iterable[Path]) -> Iterable[Path]:
-        """Drop children that are not part of the active visible set."""
-        visible = self._visible_paths
-        if visible is None:
-            return list(paths)
-        kept: list[Path] = []
-        for path in paths:
-            try:
-                relative = path.resolve().relative_to(self._compare_root_resolved)
-            except ValueError:
-                continue
-            if self._is_relative_path_visible(relative, visible):
-                kept.append(path)
-        return kept
-
-    @staticmethod
-    def _is_relative_path_visible(relative: Path, visible: set[Path]) -> bool:
-        """Return True if the relative path is either visible or an ancestor of one."""
-        if relative in visible:
-            return True
-        return any(relative in target.parents for target in visible)
-
-    @override
-    def render_label(self, node: TreeNode[DirEntry], base_style: Style, style: Style) -> Text:
+    def render_label(self, node: TreeNode[CompareTreeEntry], base_style: Style, style: Style) -> Text:
         """Render a label with compare-specific tinting and parent indicators."""
         highlight = self._highlight_for_node(node)
         label = super().render_label(node, base_style, style)
@@ -382,7 +495,7 @@ class CompareDirectoryTree(DirectoryTree):
         highlight_style = self.ROW_HIGHLIGHT_STYLES[highlight]
         return super().render_label(node, base_style + highlight_style, style + highlight_style)
 
-    def _highlight_for_node(self, node: TreeNode[DirEntry]) -> CompareRowHighlight | None:
+    def _highlight_for_node(self, node: TreeNode[CompareTreeEntry]) -> CompareRowHighlight | None:
         """Return the compare highlight for a tree node, if any."""
         relative_path = self._relative_path_for_node(node)
         if relative_path is None:
@@ -390,22 +503,18 @@ class CompareDirectoryTree(DirectoryTree):
 
         return self._row_highlights.get(relative_path)
 
-    def _shows_modified_marker(self, node: TreeNode[DirEntry]) -> bool:
+    def _shows_modified_marker(self, node: TreeNode[CompareTreeEntry]) -> bool:
         """Return whether a node should show the dim modified marker."""
         relative_path = self._relative_path_for_node(node)
         if relative_path is None:
             return False
         return relative_path in self._modified_paths or relative_path in self._modified_parent_paths
 
-    def _relative_path_for_node(self, node: TreeNode[DirEntry]) -> Path | None:
+    def _relative_path_for_node(self, node: TreeNode[CompareTreeEntry]) -> Path | None:
         """Resolve the compare-relative path for one tree node."""
         if node.data is None:
             return None
-
-        try:
-            return node.data.path.resolve().relative_to(self._compare_root_resolved)
-        except ValueError:
-            return None
+        return node.data.relative_path
 
 
 class ArchiveCompareScreen(Screen[None]):
@@ -451,14 +560,6 @@ class ArchiveCompareScreen(Screen[None]):
         self._raw_compare_result = DiffResult(archive1="", archive2="", entries=[])
         self._ordered_change_paths: list[Path] = []
         self._change_cursor: int = -1
-        self._tempdir = TemporaryDirectory(prefix="borgboi-archive-compare-")
-        self._compare_temp_root = Path(self._tempdir.name)
-        self._older_root = self._compare_temp_root / "older"
-        self._newer_root = self._compare_temp_root / "newer"
-        self._older_root_resolved = self._older_root.resolve()
-        self._newer_root_resolved = self._newer_root.resolve()
-        self._older_root.mkdir(parents=True, exist_ok=True)
-        self._newer_root.mkdir(parents=True, exist_ok=True)
         super().__init__(**kwargs)
 
     @override
@@ -473,7 +574,7 @@ class ArchiveCompareScreen(Screen[None]):
                     yield Select[str]([], prompt="Older archive", id="archive-compare-older-select", disabled=True)
                     yield Static("Older archive", id="archive-compare-older-heading", markup=True)
                     yield CompareDirectoryTree(
-                        self._older_root,
+                        "Older archive",
                         id="archive-compare-older-tree",
                     )
                 with Vertical(id="archive-compare-details", classes="archive-compare-pane"):
@@ -496,7 +597,7 @@ class ArchiveCompareScreen(Screen[None]):
                     yield Select[str]([], prompt="Newer archive", id="archive-compare-newer-select", disabled=True)
                     yield Static("Newer archive", id="archive-compare-newer-heading", markup=True)
                     yield CompareDirectoryTree(
-                        self._newer_root,
+                        "Newer archive",
                         id="archive-compare-newer-tree",
                     )
         yield Footer()
@@ -512,10 +613,6 @@ class ArchiveCompareScreen(Screen[None]):
         self.query_one("#archive-compare-older-select", Select).loading = True
         self.query_one("#archive-compare-newer-select", Select).loading = True
         self._load_archive_choices()
-
-    def on_unmount(self) -> None:
-        """Clean up any temporary mirror directories created for comparison."""
-        self._cleanup_tempdir()
 
     def action_back(self) -> None:
         """Return to the previous screen."""
@@ -605,7 +702,8 @@ class ArchiveCompareScreen(Screen[None]):
 
     @work(thread=True, exclusive=True, group="archive-compare")
     def _compare_archives(self, older_archive: str, newer_archive: str, content_only: bool) -> None:
-        """Run the archive diff and materialize the temporary mirror trees."""
+        """Run the archive diff and build compare path state."""
+        started_at = time.perf_counter()
         try:
             result = self._orchestrator.diff_archives(
                 self._repo,
@@ -614,15 +712,17 @@ class ArchiveCompareScreen(Screen[None]):
                 options=DiffOptions(content_only=content_only),
                 validated=True,
             )
+            diff_elapsed_ms = (time.perf_counter() - started_at) * 1000
             path_states = build_compare_path_states(result)
-            self._reset_compare_roots()
-            self._materialize_compare_root(
-                self._older_root,
-                [state.relative_path for state in path_states.values() if state.older_exists],
-            )
-            self._materialize_compare_root(
-                self._newer_root,
-                [state.relative_path for state in path_states.values() if state.newer_exists],
+            total_elapsed_ms = (time.perf_counter() - started_at) * 1000
+            logger.debug(
+                "Loaded archive compare diff",
+                repo_name=self._repo.name,
+                older_archive=older_archive,
+                newer_archive=newer_archive,
+                entry_count=len(result.entries),
+                diff_elapsed_ms=round(diff_elapsed_ms, 2),
+                total_elapsed_ms=round(total_elapsed_ms, 2),
             )
         except Exception as exc:
             logger.exception(
@@ -637,35 +737,15 @@ class ArchiveCompareScreen(Screen[None]):
 
         self.app.call_from_thread(self._apply_compare_result, result, path_states, content_only)
 
-    def _reset_compare_roots(self) -> None:
-        """Clear any previous synthetic compare tree contents."""
-        for root in (self._older_root, self._newer_root):
-            shutil.rmtree(root, ignore_errors=True)
-            root.mkdir(parents=True, exist_ok=True)
-
-    def _materialize_compare_root(self, root: Path, paths: list[Path]) -> None:
-        """Write a lightweight filesystem mirror for a set of changed paths."""
-        normalized_paths = {path for path in paths if path.parts}
-        parent_directories = {parent for path in normalized_paths for parent in path.parents if parent.parts}
-
-        for directory in sorted(parent_directories, key=lambda item: (len(item.parts), item.as_posix())):
-            (root / directory).mkdir(parents=True, exist_ok=True)
-
-        for relative_path in sorted(normalized_paths, key=lambda item: item.as_posix()):
-            target = root / relative_path
-            if relative_path in parent_directories:
-                target.mkdir(parents=True, exist_ok=True)
-                continue
-
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.touch(exist_ok=True)
-
     def _apply_compare_result(
         self, result: DiffResult, path_states: dict[Path, ComparePathState], content_only: bool
     ) -> None:
         """Render the compare result after the background worker finishes."""
+        started_at = time.perf_counter()
         self._raw_compare_result = result
         self._raw_path_states = path_states
+        self._older_tree.set_path_index(state.relative_path for state in path_states.values() if state.older_exists)
+        self._newer_tree.set_path_index(state.relative_path for state in path_states.values() if state.newer_exists)
         self._set_compare_controls_enabled(True)
         self.query_one("#archive-compare-status", Label).update(
             self._render_status_line(result.archive1, result.archive2, content_only)
@@ -676,6 +756,14 @@ class ArchiveCompareScreen(Screen[None]):
         self._change_cursor = -1
         self.selected_path = None
         self._apply_filters()
+        logger.debug(
+            "Rendered archive compare result",
+            repo_name=self._repo.name,
+            older_archive=result.archive1,
+            newer_archive=result.archive2,
+            entry_count=len(result.entries),
+            elapsed_ms=round((time.perf_counter() - started_at) * 1000, 2),
+        )
 
     def _clear_compare_view(self, older_archive: str, newer_archive: str) -> None:
         """Remove any previous compare data from the screen."""
@@ -688,16 +776,16 @@ class ArchiveCompareScreen(Screen[None]):
         self._change_cursor = -1
         self.expanded_paths = frozenset()
         self.selected_path = None
-        self._reset_compare_roots()
+        self._older_tree.set_path_index(())
+        self._newer_tree.set_path_index(())
         self._older_tree.set_visible_paths(None)
         self._newer_tree.set_visible_paths(None)
         self._older_tree.set_compare_overlays(highlights={}, modified_paths=set(), modified_parent_paths=set())
         self._newer_tree.set_compare_overlays(highlights={}, modified_paths=set(), modified_parent_paths=set())
-        _ = self._older_tree.reload()
-        _ = self._newer_tree.reload()
 
     def _apply_filters(self) -> None:
         """Recompute visible states, overlays, and tree visibility from reactives."""
+        started_at = time.perf_counter()
         raw = self._raw_compare_result
         kinds = self.kind_filters
         needle = self.path_search
@@ -735,9 +823,6 @@ class ArchiveCompareScreen(Screen[None]):
         self._older_tree.set_visible_paths(older_visible if filter_active else None)
         self._newer_tree.set_visible_paths(newer_visible if filter_active else None)
 
-        _ = self._older_tree.reload()
-        _ = self._newer_tree.reload()
-
         if self.selected_path not in visible_states:
             self.selected_path = None
             self._change_cursor = -1
@@ -747,6 +832,14 @@ class ArchiveCompareScreen(Screen[None]):
             "No changed paths to inspect." if not visible_states else "No path selected."
         )
         self.query_one("#archive-compare-kind-filters", Static).update(self._render_kind_filter_chips(kinds))
+        logger.debug(
+            "Applied archive compare filters",
+            repo_name=self._repo.name,
+            raw_entry_count=len(raw.entries),
+            visible_entry_count=len(filtered_result.entries),
+            filter_active=filter_active,
+            elapsed_ms=round((time.perf_counter() - started_at) * 1000, 2),
+        )
 
     def _filters_are_active(self) -> bool:
         """Return whether any filter narrows the visible path set."""
@@ -930,12 +1023,8 @@ class ArchiveCompareScreen(Screen[None]):
             return
         self._start_compare()
 
-    def on_directory_tree_file_selected(self, event: DirectoryTree.FileSelected) -> None:
-        """Update the detail panel when a file is selected in either tree."""
-        self._show_selected_path(event.path)
-
-    def on_directory_tree_directory_selected(self, event: DirectoryTree.DirectorySelected) -> None:
-        """Update the detail panel when a directory is selected in either tree."""
+    def on_compare_directory_tree_path_selected(self, event: CompareDirectoryTree.PathSelected) -> None:
+        """Update the detail panel when a path is selected in either tree."""
         self._show_selected_path(event.path)
 
     def on_compare_directory_tree_directory_expanded(self, event: CompareDirectoryTree.DirectoryExpanded) -> None:
@@ -948,8 +1037,8 @@ class ArchiveCompareScreen(Screen[None]):
 
     def _update_expanded_path(self, directory_path: Path, *, expanded: bool) -> None:
         """Update the shared expansion state from a tree event."""
-        relative_path = self._relative_compare_path(directory_path)
-        if relative_path is None or not relative_path.parts:
+        relative_path = directory_path
+        if not relative_path.parts:
             return
 
         relative_path_str = relative_path.as_posix()
@@ -1006,9 +1095,7 @@ class ArchiveCompareScreen(Screen[None]):
 
     def _show_selected_path(self, selected_path: Path) -> None:
         """Render details for the selected compare path or directory."""
-        relative_path = self._relative_compare_path(selected_path)
-        if relative_path is None:
-            return
+        relative_path = selected_path
 
         self._render_selection_from_relative_path(relative_path)
 
@@ -1024,16 +1111,6 @@ class ArchiveCompareScreen(Screen[None]):
 
         self.selected_path = None
         self._change_cursor = -1
-
-    def _relative_compare_path(self, absolute_path: Path) -> Path | None:
-        """Convert an absolute selected path into a relative compare path."""
-        resolved_path = absolute_path.resolve()
-        for root in (self._older_root_resolved, self._newer_root_resolved):
-            try:
-                return resolved_path.relative_to(root)
-            except ValueError:
-                continue
-        return None
 
     def _render_archive_heading(self, archive_name: str) -> str:
         """Render a heading for one side of the compare view."""
@@ -1067,14 +1144,3 @@ class ArchiveCompareScreen(Screen[None]):
                 ),
             ]
         )
-
-    def _cleanup_tempdir(self) -> None:
-        """Release the synthetic compare tree directory."""
-        try:
-            self._tempdir.cleanup()
-        except OSError as exc:
-            logger.warning(
-                "Failed to clean up temporary compare directory",
-                tempdir=self._compare_temp_root.as_posix(),
-                error=str(exc),
-            )

--- a/src/borgboi/tui/features/archive_compare/screen.py
+++ b/src/borgboi/tui/features/archive_compare/screen.py
@@ -31,7 +31,7 @@ from textual.widgets import (
 )
 from textual.widgets.tree import TreeNode
 
-from borgboi.clients.borg import DiffChange, DiffResult, RepoArchive
+from borgboi.clients.borg_models import DiffChange, DiffResult, RepoArchive
 from borgboi.core.errors import ValidationError
 from borgboi.core.logging import get_logger
 from borgboi.core.models import DiffOptions

--- a/src/borgboi/tui/features/repo_detail/info_screen.py
+++ b/src/borgboi/tui/features/repo_detail/info_screen.py
@@ -28,7 +28,7 @@ from textual.widgets import (
     TextArea,
 )
 
-from borgboi.clients.borg import RepoArchive, RepoInfo
+from borgboi.clients.borg_models import RepoArchive, RepoInfo
 from borgboi.core.logging import get_logger
 from borgboi.core.models import RetentionPolicy
 from borgboi.lib.utils import calculate_archive_age, format_iso_timestamp, format_last_backup, format_repo_size

--- a/tests/backup_cli_test.py
+++ b/tests/backup_cli_test.py
@@ -10,7 +10,7 @@ from borgboi.cli.backup import (
     _build_archive_stats_tables,
     _render_diff_result,
 )
-from borgboi.clients.borg import ArchiveInfo, DiffResult
+from borgboi.clients.borg_models import ArchiveInfo, DiffResult
 from borgboi.core.models import BackupOptions, DiffOptions
 from borgboi.lib.diff import format_diff_change, summarize_diff_changes
 from tests.cli_helpers import invoke_cli

--- a/tests/core_logging_test.py
+++ b/tests/core_logging_test.py
@@ -558,7 +558,7 @@ def test_dynamodb_client_logs_structured_events(
         deduped_size=250,
     )
 
-    monkeypatch.setattr("borgboi.clients.dynamodb.borg.info", lambda repo_path, passphrase=None: None)
+    monkeypatch.setattr("borgboi.clients.dynamodb._get_borg_client", lambda: Mock(info=lambda *args, **kwargs: None))
 
     add_repo_to_table(repo)
     add_archive_to_table(archive)

--- a/tests/core_orchestrator_workflows_test.py
+++ b/tests/core_orchestrator_workflows_test.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY, Mock
 
 import pytest
 
-from borgboi.clients.borg import Encryption, RepoCache, RepoInfo, Repository, Stats
+from borgboi.clients.borg_models import Encryption, RepoCache, RepoInfo, Repository, Stats
 from borgboi.config import Config
 from borgboi.core.errors import RepositoryNotFoundError, StorageError, ValidationError
 from borgboi.core.models import DiffOptions, RetentionPolicy

--- a/tests/diff_test.py
+++ b/tests/diff_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from borgboi.clients.borg import DiffResult
+from borgboi.clients.borg_models import DiffResult
 from borgboi.lib.diff import filter_diff_result, resolve_entry_kind
 
 

--- a/tests/dynamodb_test.py
+++ b/tests/dynamodb_test.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 def get_mock_metadata(repo_path: Path) -> str:
     """Return a mock JSON string representing a Borg repository's metadata."""
-    from borgboi.clients.borg import Encryption, RepoCache, RepoInfo, Repository, Stats
+    from borgboi.clients.borg_models import Encryption, RepoCache, RepoInfo, Repository, Stats
 
     repo_info = RepoInfo(
         cache=RepoCache(
@@ -40,7 +40,7 @@ def get_mock_metadata(repo_path: Path) -> str:
 
 @pytest.fixture
 def borgboi_repo(repo_storage_dir: Path, backup_target_dir: Path) -> BorgBoiRepo:
-    from borgboi.clients.borg import RepoInfo
+    from borgboi.clients.borg_models import RepoInfo
 
     metadata_json_str = get_mock_metadata(repo_storage_dir)
     return BorgBoiRepo(

--- a/tests/test_dynamodb_storage.py
+++ b/tests/test_dynamodb_storage.py
@@ -67,7 +67,9 @@ def test_get_by_path_defaults_to_current_hostname(
     repo = _make_repo(hostname="storage-host")
     storage.save(repo)
     monkeypatch.setattr("borgboi.storage.dynamodb.socket.gethostname", lambda: "storage-host")
-    monkeypatch.setattr("borgboi.clients.dynamodb.borg.info", lambda repo_path, passphrase=None: None)
+    monkeypatch.setattr(
+        "borgboi.clients.dynamodb._get_borg_client", lambda: SimpleNamespace(info=lambda *args, **kwargs: None)
+    )
 
     result = storage.get_by_path(repo.path)
 

--- a/tests/tui/archive_compare_screen_test.py
+++ b/tests/tui/archive_compare_screen_test.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 import pytest
 from rich.style import Style
-from textual.widgets import DirectoryTree, Input, Select, Static, Switch
+from textual.widgets import Input, Select, Static, Switch
 
 from borgboi.clients.borg import DiffResult, RepoArchive, RepoInfo
 from borgboi.config import Config
@@ -16,6 +16,7 @@ from borgboi.tui.app import BorgBoiApp
 from borgboi.tui.features.archive_compare import (
     ArchiveCompareScreen,
     CompareDirectoryTree,
+    ComparePathIndex,
     build_compare_path_states,
     build_compare_tree_highlights,
     build_compare_tree_modified_paths,
@@ -164,6 +165,29 @@ def test_build_compare_tree_parent_indicators_marks_ancestor_only_directories() 
     assert Path("direct-dir") not in newer_indicators
 
 
+def test_compare_path_index_returns_visible_children_without_filesystem_mirror() -> None:
+    index = ComparePathIndex.from_paths(
+        [
+            Path("docs/file.txt"),
+            Path("docs/subdir/nested.txt"),
+            Path("removed.txt"),
+        ]
+    )
+
+    assert tuple(index.iter_visible_children(Path(), None)) == (Path("docs"), Path("removed.txt"))
+    assert tuple(index.iter_visible_children(Path("docs"), None)) == (Path("docs/subdir"), Path("docs/file.txt"))
+    assert tuple(index.iter_visible_children(Path(), {Path("docs/subdir/nested.txt")})) == (Path("docs"),)
+    assert tuple(index.iter_visible_children(Path("docs"), {Path("docs/subdir/nested.txt")})) == (Path("docs/subdir"),)
+    assert index.has_children(Path("docs")) is True
+    assert index.has_children(Path("docs/file.txt")) is False
+
+
+def test_compare_directory_tree_processes_path_labels_with_spaces_literally() -> None:
+    tree = CompareDirectoryTree("Archive")
+
+    assert tree.process_label("My Documents/report final.txt").plain == "My Documents/report final.txt"
+
+
 async def _open_archive_compare_screen(app: BorgBoiApp, pilot: Any) -> ArchiveCompareScreen:
     await pilot.pause()
     await pilot.press("i")
@@ -184,26 +208,23 @@ async def test_archive_compare_screen_builds_changed_path_trees(archive_compare_
     async with archive_compare_app.run_test() as pilot:
         screen = await _open_archive_compare_screen(archive_compare_app, pilot)
 
-        older_tree = screen.query_one("#archive-compare-older-tree", DirectoryTree)
-        newer_tree = screen.query_one("#archive-compare-newer-tree", DirectoryTree)
+        older_tree = screen.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        newer_tree = screen.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
         summary = screen.query_one("#archive-compare-summary", Static)
         older_select = screen.query_one("#archive-compare-older-select", Select)
         newer_select = screen.query_one("#archive-compare-newer-select", Select)
         content_only = screen.query_one("#archive-compare-content-only-switch", Switch)
 
-        assert screen._compare_temp_root.exists() is True
-        assert older_tree.path == screen._older_root
-        assert newer_tree.path == screen._newer_root
         assert older_select.value == "2026-03-27_22:00:00"
         assert newer_select.value == "2026-03-28_22:00:00"
         assert content_only.value is False
 
-        assert (screen._older_root / "removed.txt").exists() is True
-        assert (screen._newer_root / "removed.txt").exists() is False
-        assert (screen._older_root / "added.txt").exists() is False
-        assert (screen._newer_root / "added.txt").exists() is True
-        assert (screen._older_root / "docs" / "file.txt").exists() is True
-        assert (screen._newer_root / "docs" / "file.txt").exists() is True
+        assert await older_tree.find_node_by_relative_path(Path("removed.txt")) is not None
+        assert await newer_tree.find_node_by_relative_path(Path("removed.txt")) is None
+        assert await older_tree.find_node_by_relative_path(Path("added.txt")) is None
+        assert await newer_tree.find_node_by_relative_path(Path("added.txt")) is not None
+        assert await older_tree.find_node_by_relative_path(Path("docs/file.txt")) is not None
+        assert await newer_tree.find_node_by_relative_path(Path("docs/file.txt")) is not None
         assert "Changed paths" in str(cast(Any, summary).content)
         assert "2026-03-27_22:00:00" in str(cast(Any, summary).content)
         assert "2026-03-28_22:00:00" in str(cast(Any, summary).content)
@@ -413,7 +434,7 @@ async def test_archive_compare_screen_updates_selected_path_details(archive_comp
     async with archive_compare_app.run_test() as pilot:
         screen = await _open_archive_compare_screen(archive_compare_app, pilot)
 
-        screen._show_selected_path(screen._newer_root / "docs" / "file.txt")
+        screen._show_selected_path(Path("docs/file.txt"))
         await pilot.pause()
 
         selection = screen.query_one("#archive-compare-selection", Static)
@@ -429,11 +450,11 @@ async def test_archive_compare_screen_clears_selected_file_when_directory_select
     async with archive_compare_app.run_test() as pilot:
         screen = await _open_archive_compare_screen(archive_compare_app, pilot)
 
-        screen._show_selected_path(screen._newer_root / "docs" / "file.txt")
+        screen._show_selected_path(Path("docs/file.txt"))
         await pilot.pause()
         assert screen.selected_path == Path("docs/file.txt")
 
-        screen._show_selected_path(screen._newer_root / "docs")
+        screen._show_selected_path(Path("docs"))
         await pilot.pause()
 
         assert screen.selected_path is None
@@ -445,7 +466,7 @@ async def test_archive_compare_screen_clears_selected_file_when_filters_hide_it(
     async with archive_compare_app.run_test() as pilot:
         screen = await _open_archive_compare_screen(archive_compare_app, pilot)
 
-        screen._show_selected_path(screen._newer_root / "docs" / "file.txt")
+        screen._show_selected_path(Path("docs/file.txt"))
         await pilot.pause()
         assert screen.selected_path == Path("docs/file.txt")
 
@@ -456,17 +477,14 @@ async def test_archive_compare_screen_clears_selected_file_when_filters_hide_it(
         assert screen.selected_path is None
 
 
-async def test_archive_compare_screen_cleans_up_tempdir_on_dismiss(archive_compare_app: BorgBoiApp) -> None:
+async def test_archive_compare_screen_dismisses_to_repo_details(archive_compare_app: BorgBoiApp) -> None:
     async with archive_compare_app.run_test() as pilot:
-        screen = await _open_archive_compare_screen(archive_compare_app, pilot)
-        temp_root = screen._compare_temp_root
-
-        assert temp_root.exists() is True
+        await _open_archive_compare_screen(archive_compare_app, pilot)
 
         await pilot.press("escape")
         await pilot.pause()
 
-        assert temp_root.exists() is False
+        assert isinstance(archive_compare_app.screen, RepoInfoScreen)
 
 
 async def test_archive_compare_screen_kind_filter_prunes_overlays_and_summary(
@@ -675,7 +693,8 @@ async def test_archive_compare_screen_clears_previous_diff_after_compare_failure
         screen = await _open_archive_compare_screen(archive_compare_app, pilot)
 
         assert screen._path_states
-        assert (screen._older_root / "removed.txt").exists() is True
+        older_tree = screen.query_one("#archive-compare-older-tree", CompareDirectoryTree)
+        assert await older_tree.find_node_by_relative_path(Path("removed.txt")) is not None
 
         def _raise_diff_failure(*_args: Any, **_kwargs: Any) -> DiffResult:
             raise RuntimeError("compare boom")
@@ -693,8 +712,9 @@ async def test_archive_compare_screen_clears_previous_diff_after_compare_failure
         newer_heading = screen.query_one("#archive-compare-newer-heading", Static)
 
         assert screen._path_states == {}
-        assert (screen._older_root / "removed.txt").exists() is False
-        assert (screen._newer_root / "added.txt").exists() is False
+        assert await older_tree.find_node_by_relative_path(Path("removed.txt")) is None
+        newer_tree = screen.query_one("#archive-compare-newer-tree", CompareDirectoryTree)
+        assert await newer_tree.find_node_by_relative_path(Path("added.txt")) is None
         assert "Archive comparison failed" in str(cast(Any, summary).content)
         assert "2026-03-27_22:00:00" in str(cast(Any, older_heading).content)
         assert "2026-03-28_22:00:00" in str(cast(Any, newer_heading).content)

--- a/tests/tui/archive_compare_screen_test.py
+++ b/tests/tui/archive_compare_screen_test.py
@@ -9,7 +9,7 @@ import pytest
 from rich.style import Style
 from textual.widgets import Input, Select, Static, Switch
 
-from borgboi.clients.borg import DiffResult, RepoArchive, RepoInfo
+from borgboi.clients.borg_models import DiffResult, RepoArchive, RepoInfo
 from borgboi.config import Config
 from borgboi.core.models import Repository
 from borgboi.tui.app import BorgBoiApp

--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 import pytest
 
-from borgboi.clients.borg import RepoArchive, RepoInfo
+from borgboi.clients.borg_models import RepoArchive, RepoInfo
 from borgboi.config import Config
 from borgboi.core.models import RepoMetadata, Repository, RetentionPolicy
 from borgboi.models import BorgBoiRepo

--- a/tests/tui/repo_info_screen_test.py
+++ b/tests/tui/repo_info_screen_test.py
@@ -7,7 +7,7 @@ import pytest
 from textual.containers import VerticalScroll
 from textual.widgets import Button, DataTable, DirectoryTree, Input, Label, Static, TabbedContent, TabPane, TextArea
 
-from borgboi.clients.borg import RepoArchive, RepoInfo
+from borgboi.clients.borg_models import RepoArchive, RepoInfo
 from borgboi.config import Config
 from borgboi.core.models import Repository, RetentionPolicy
 from borgboi.tui.app import BorgBoiApp

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-26T02:47:05.6063654Z"
+exclude-newer = "2026-04-26T02:48:05.509530933Z"
 exclude-newer-span = "PT24H"
 
 [[package]]
@@ -273,29 +273,29 @@ docs = [{ name = "zensical", specifier = ">=0.0.24" }]
 
 [[package]]
 name = "boto3"
-version = "1.42.94"
+version = "1.42.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/6a/95302333208830de932ad1d0b69599ee13e936349a44981fb72632507861/boto3-1.42.94.tar.gz", hash = "sha256:5b6056a661c19e974aaea3cb97690ddbe30d10c31e4f887df3bff06574f34510", size = 113211, upload-time = "2026-04-22T20:36:19.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/2d/69fb3acd50bab83fb295c167d33c4b653faeb5fb0f42bfca4d9b69d6fb68/boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68", size = 113203, upload-time = "2026-04-24T19:47:18.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/6f/4e175604f3168befcb413c95bf45eada67d12042f92f76a9305d6a817ea9/boto3-1.42.94-py3-none-any.whl", hash = "sha256:56d53bce75629cc7c78a32da8b62de74cee3e2a3d54a2b60ba1a65f9f1b129da", size = 140555, upload-time = "2026-04-22T20:36:16.182Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9d/b3f617d011c42eb804d993103b8fa9acdce153e181a3042f58bfe33d7cb4/boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24", size = 140557, upload-time = "2026-04-24T19:47:15.824Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.42.94"
+version = "1.42.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/f5/355be07c27e7e7261e70ad9190b3d2950dafd9e7db6346b44d4941f1ed8e/boto3_stubs-1.42.94.tar.gz", hash = "sha256:63eb0a0487636fcc286ab9f3d7f41be30dec036bbd7ab89c3ccd29afe00bd9e7", size = 102707, upload-time = "2026-04-22T21:31:11.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/86/65f45f84621cccc2471871088bab8fe515b4346ba9e48d9001484ec440d6/boto3_stubs-1.42.96.tar.gz", hash = "sha256:1e7819c34d1eae8e5e3cfaf9d144fdcad65aad184b380488871de1d0b2851879", size = 102691, upload-time = "2026-04-24T20:25:13.984Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/d6/4c06ec679c72d0bf7edba930b9ec354c8edadf53dabf42304929d5da8939/boto3_stubs-1.42.94-py3-none-any.whl", hash = "sha256:855319e063d4b3d3f627a57a1819da4bbf3e4c621189fcb2f47465ecfec932da", size = 70666, upload-time = "2026-04-22T21:31:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/bdac1ff9fd4321091183776c5adffce5fc7b4d0fec7e38af9064e24a2497/boto3_stubs-1.42.96-py3-none-any.whl", hash = "sha256:2c112e257f40006147a53f6f62075804689154271973b2807f5656feaa804216", size = 70668, upload-time = "2026-04-24T20:25:09.736Z" },
 ]
 
 [package.optional-dependencies]
@@ -311,16 +311,16 @@ essential = [
 
 [[package]]
 name = "botocore"
-version = "1.42.94"
+version = "1.42.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/90/1a4d0e81b325d38e37f81d907ceacac3b8f509ad38b495bb95086ecb609d/botocore-1.42.94.tar.gz", hash = "sha256:41c6b3b11b073221a41f52b222ba387be34459fb77cdc506e8b74cdaf24bdcce", size = 15260901, upload-time = "2026-04-22T20:36:00.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/77/2c333622a1d47cf5bf73cdcab0cb6c92addafbef2ec05f81b9f75687d9e5/botocore-1.42.96.tar.gz", hash = "sha256:75b3b841ffacaa944f645196655a21ca777591dd8911e732bfb6614545af0250", size = 15263344, upload-time = "2026-04-24T19:47:05.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/73/313af9ee02ac0155247bcf3f04fcf54fcae2e33250bb437528c18aeefd81/botocore-1.42.94-py3-none-any.whl", hash = "sha256:a2143742132ed0f6cdb90204d667b89d0301068b1045e8bc099efa267bf1b348", size = 14942938, upload-time = "2026-04-22T20:35:55.663Z" },
+    { url = "https://files.pythonhosted.org/packages/45/56/152c3a859ca1b9d77ed16deac3cf81682013677c68cf5715698781fc81bd/botocore-1.42.96-py3-none-any.whl", hash = "sha256:db2c3e2006628be6fde81a24124a6563c363d6982fb92728837cf174bad9d98a", size = 14945920, upload-time = "2026-04-24T19:47:00.323Z" },
 ]
 
 [[package]]
@@ -618,55 +618,55 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ wheels = [
 
 [[package]]
 name = "inline-snapshot"
-version = "0.32.6"
+version = "0.32.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asttokens" },
@@ -962,9 +962,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/df/d831f0312478b4feb7c3195291071dd13f130176fcdcae2d6d2a2d5fda1d/inline_snapshot-0.32.6.tar.gz", hash = "sha256:224a96eeb86c4b2831d274239d3468dc0b7819264f608f595b2f9d01f79a6e38", size = 2627401, upload-time = "2026-04-10T05:46:22.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/ff/86b039f42822958012e92db85878655ef49e3e9887d2d9c95e27dab3ee51/inline_snapshot-0.32.7.tar.gz", hash = "sha256:1a97a50420de32b86c422cceadf950f1f343ba03a28b878a757ee492b741c093", size = 2630267, upload-time = "2026-04-23T19:00:44.566Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c7/8b54418a67ef2b10771a82d03e2b6b69016e5bfb0527fd491884a890e1d6/inline_snapshot-0.32.6-py3-none-any.whl", hash = "sha256:1f8fb6353dff0aa824e00eecf17d53d7d08d36f2167752756ec8ea73f39d7e15", size = 85157, upload-time = "2026-04-10T05:46:21.402Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/2c/31453f42995e22ff5cb12694796b6e7890b3e06ea1ba10d3f5cf5fde6b18/inline_snapshot-0.32.7-py3-none-any.whl", hash = "sha256:6ea0e211daf9192aeb91ab82ba90e5bb628414696c9a5d3bc4db1c5ba459c4c6", size = 85439, upload-time = "2026-04-23T19:00:42.472Z" },
 ]
 
 [[package]]
@@ -1481,32 +1481,32 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.41.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.41.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1517,14 +1517,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/63/d9f43cd75f3fabb7e01148c89cfa9491fc18f6580a6764c554ff7c953c46/opentelemetry_exporter_otlp_proto_http-1.41.0.tar.gz", hash = "sha256:dcd6e0686f56277db4eecbadd5262124e8f2cc739cadbc3fae3d08a12c976cf5", size = 24139, upload-time = "2026-04-09T14:38:38.128Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b5/a214cd907eedc17699d1c2d602288ae17cb775526df04db3a3b3585329d2/opentelemetry_exporter_otlp_proto_http-1.41.0-py3-none-any.whl", hash = "sha256:a9c4ee69cce9c3f4d7ee736ad1b44e3c9654002c0816900abbafd9f3cf289751", size = 22673, upload-time = "2026-04-09T14:38:18.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.62b0"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1532,14 +1532,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/fd/b8e90bb340957f059084376f94cff336b0e871a42feba7d3f7342365e987/opentelemetry_instrumentation-0.62b0.tar.gz", hash = "sha256:aa1b0b9ab2e1722c2a8a5384fb016fc28d30bba51826676c8036074790d2861e", size = 34042, upload-time = "2026-04-09T14:40:22.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/b6/3356d2e335e3c449c5183e9b023f30f04f1b7073a6583c68745ea2e704b1/opentelemetry_instrumentation-0.62b0-py3-none-any.whl", hash = "sha256:30d4e76486eae64fb095264a70c2c809c4bed17b73373e53091470661f7d477c", size = 34158, upload-time = "2026-04-09T14:39:21.428Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-botocore"
-version = "0.62b0"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1548,9 +1548,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/18/c83a49636eb8d6e896c52cfbcf44cd7386de67db19b283d21dd635dafd5d/opentelemetry_instrumentation_botocore-0.62b0.tar.gz", hash = "sha256:70a8cb9b796a986619c6540784c3258496062794c7ee4cd56ca1d6e935391375", size = 125966, upload-time = "2026-04-09T14:40:30.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/b8/47f6b6eb37f790f0de4339d6ca05b5222877c8327c1f0a967e6b443494d9/opentelemetry_instrumentation_botocore-0.62b1.tar.gz", hash = "sha256:2191ebfbb9cd6354ef1de6c0dd127c1cc847fabb7c9c25b8d000e766ce1b5671", size = 125970, upload-time = "2026-04-24T13:22:43.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ac/dec0309528b6f824c9b078adeb38a99fe0d86b87c9ba9e6093f937ed09b0/opentelemetry_instrumentation_botocore-0.62b0-py3-none-any.whl", hash = "sha256:ad6066681c023aa4f5f0c0b2ce4c50edab3f668ab887de623a397090fc683bb3", size = 40516, upload-time = "2026-04-09T14:39:33.181Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/45/a2d8655d4f2b2c135943ca99fde9698685ef33f4229daf1263873f34bd0e/opentelemetry_instrumentation_botocore-0.62b1-py3-none-any.whl", hash = "sha256:7768cc2650b979649fe3475238baa7779e4194e25997d164b7eca276db559d43", size = 40517, upload-time = "2026-04-24T13:21:44.429Z" },
 ]
 
 [[package]]
@@ -1567,41 +1567,41 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.41.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.41.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.62b0"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
 ]
 
 [[package]]
@@ -1659,20 +1659,20 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
 ]
 
 [[package]]
@@ -2225,27 +2225,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -3057,7 +3057,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.34"
+version = "0.0.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3068,20 +3068,20 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/2c/4e9d0043f05d4e3700a60e19c5e30906a676bf8cd56629acfa34477ef2f6/zensical-0.0.34.tar.gz", hash = "sha256:db5d60659142d697396147a6b62744ea6038e14dc58591e92f86dfee80f6d54d", size = 3893034, upload-time = "2026-04-21T09:11:40.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/e9/8d0e66ad113e702d7f5eed2cc5ad0f035cb212c49b0415553473f2da900b/zensical-0.0.36.tar.gz", hash = "sha256:32126c57fd241267e55c863f2bdd31bfe4422c376280e74e4a1036a89c0d513c", size = 3897092, upload-time = "2026-04-23T15:37:46.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/00/bde67cda35ac9f082cb06242f1888724051d3a8248fec432e704c878215d/zensical-0.0.34-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:532f71239842993174c05f470dee5dde81a064e3b81721260e9926a211760f2b", size = 12513531, upload-time = "2026-04-21T09:11:04.846Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/d0/9259a10f603ea38f3ae22569d6ab70b05a60065b9659e59775efae8364fa/zensical-0.0.34-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:334ac036f8fe64f805853f5553e5edc45336bb97e799475a218b98652d296eb2", size = 12381090, upload-time = "2026-04-21T09:11:07.599Z" },
-    { url = "https://files.pythonhosted.org/packages/43/2c/0d00b29283a15dc664a253d18a08e58c2ae6dfde0a28f60ce0ea77c77b7e/zensical-0.0.34-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb9d880ccb25edba332e1f310b40e65afb0e1072c69530ec02afc6179b33c5ec", size = 12761246, upload-time = "2026-04-21T09:11:10.751Z" },
-    { url = "https://files.pythonhosted.org/packages/06/1f/702b22eadb09da1b56243113b8317d3e6f0925ef2e5862b8fb6a34703e36/zensical-0.0.34-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3883e3456b393d49eabe61bacdd2d14410ddec0813849bf823fd599a6810bff", size = 12701113, upload-time = "2026-04-21T09:11:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/12/7694a8f2e7a88a2c4a9e29484b61d5d57968b3e31f5d23a0fa4f2289f637/zensical-0.0.34-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ec58574c85bfead097be5673ab79768a84ab747e85663e506fec7fd7036ebc5", size = 13043815, upload-time = "2026-04-21T09:11:16.536Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8d/41f07d5ae6cf722ff420098d7d4f1d73614f0719d66adb8ff9aa11ad66d3/zensical-0.0.34-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d504c900fcebe2f4b7c418e9554262b3258294c7913514218d9e0c38cdbf315e", size = 12786424, upload-time = "2026-04-21T09:11:19.529Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d8/1b29f33887c6237ecd22382d6d4e56b08dc3b5a555b8414c2131374bce8a/zensical-0.0.34-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a4021a311e0def81c261c4474ac5476f3c48a1666220f678e6ff3e619bbd72f4", size = 12936593, upload-time = "2026-04-21T09:11:23.011Z" },
-    { url = "https://files.pythonhosted.org/packages/29/91/578f5a60acbf7358d4a09007d73281a5841d16d9b8ffb5e78f3244f728f5/zensical-0.0.34-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:a596cb874a991330760363e4f76ad717463673d7d22e4172360661cfa040feb7", size = 12976812, upload-time = "2026-04-21T09:11:26.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/35/7a596c9eb7e5eb31a9076f494a6ab8921cdb9627e9d322caf05a88ff2bb2/zensical-0.0.34-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:56239b81c9ce549074ed48d2bc391427fecd43899b6d5e7cc57211ce4dd78a21", size = 13114535, upload-time = "2026-04-21T09:11:29.741Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ce/a1382259b028e44486fe2e22abae8d634a640ec72d98824c7e1248550afc/zensical-0.0.34-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f77cb1152b51ccc5bf0c1055ac06802a6eeeff9cb8b4293919300c0becbd26bd", size = 13064408, upload-time = "2026-04-21T09:11:32.497Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/69/e3644fe29a84f880be29c8085c8ced651f9213ea8b3422138b666a2450a4/zensical-0.0.34-cp310-abi3-win32.whl", hash = "sha256:57151aed0915dc1d1bf1de73da53b0c8e55d6c8beae9722c2fe246e7168d8495", size = 12079504, upload-time = "2026-04-21T09:11:35.499Z" },
-    { url = "https://files.pythonhosted.org/packages/60/49/c2cbf4dfd7fc82fa383c94104ad7570a751bcc78c16b3d0a4dae9d5e77bf/zensical-0.0.34-cp310-abi3-win_amd64.whl", hash = "sha256:9f604126356bf6d78fed09e33192f881897ba6c507c2df3790e130bb77009499", size = 12298457, upload-time = "2026-04-21T09:11:38.292Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ff/2846737502a9ae783570b32aac4f20f5232512fbf245bbf1c0398728c7ed/zensical-0.0.36-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3d42312267c4124ed67ddfd2809167bdd3ea4f71892c8a20897be98b66da8b73", size = 12515534, upload-time = "2026-04-23T15:37:07.815Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e9/443b561793ed6626cb46c328fd8fd916a7b18e5af5349934c5346438548c/zensical-0.0.36-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8462c133c8da5234cd301ad3c722d52d66a0092a51b7b93e2ce12f217976b29b", size = 12384874, upload-time = "2026-04-23T15:37:11.617Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/faecf0a5dff381ff331b7b87d385c8335ca0b7297a33d85abc3313cfa598/zensical-0.0.36-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0a6dc86dc0d8488b18c6501d62b63989a538350a33173347da8b9f1f54bed2c", size = 12764889, upload-time = "2026-04-23T15:37:14.512Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/56/1ddee63d323d779733e5bf00e99c878f03e50b77f294711a850c1e1ceddb/zensical-0.0.36-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d31c726d7f13601a568a2a9e80592472da24657ff5428ef15c2c95bc458cb65b", size = 12705679, upload-time = "2026-04-23T15:37:18.038Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/61/4b264b1466251450856ed4768fa9a793f7c24172039f47f562cd899e0744/zensical-0.0.36-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a7e8b32e41784d19122cb16a0bd6fcb53852177ce689ceba1ba7a8bb20fe3a0", size = 13057470, upload-time = "2026-04-23T15:37:21.594Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9b/c44a1ebc2fe8daadecbd9ea41c498e545c494204e239314347fbcec51159/zensical-0.0.36-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abe5d24716107edb033c2326c816b891952b98b9637c5308f5320712a2e70aac", size = 12792788, upload-time = "2026-04-23T15:37:24.784Z" },
+    { url = "https://files.pythonhosted.org/packages/97/94/4d0e345f75f892fce029b513a26f4491b6dd39ff73c5bee3f8fbb9305e8c/zensical-0.0.36-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9ed7a54465b497d1548aeb6b38a99ac6f45c8f191a5cf2a180902af28c0cd58a", size = 12940940, upload-time = "2026-04-23T15:37:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2e/4612b97d8d493a6ac591ebb28a6b3a592eb4d969bbb8a92311125fe0b874/zensical-0.0.36-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:282eb4eaf7cd3bd389a4b826c1c13a30136e5c6fcfcafce26fc27cd05acc660f", size = 12980355, upload-time = "2026-04-23T15:37:30.998Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/90/c1a91b503aec105cdb7ccf4d466e8612c113186f090c61d795272cecce27/zensical-0.0.36-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:36d5719df268697dbcf7aa5bbea9eea353501c80b1c6c17d6c7f2c69405be9af", size = 13124220, upload-time = "2026-04-23T15:37:34.506Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e0/b9ffadaff0b80498699aaf0f2bcc0b659db074fd94071520d22f035e5125/zensical-0.0.36-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7771aaf33f7d06f779e041930812fe65f5f97a6f4fbd1c7e51924ce1a27c0c66", size = 13070894, upload-time = "2026-04-23T15:37:38.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c3/aea29875f7b89d7c79b84a30259356404bf778d42c27c36632ef19aa826c/zensical-0.0.36-cp310-abi3-win32.whl", hash = "sha256:61f1dff7c38a8d0acb054c11426c25f0a57b973703eb3d0bf1e8cc04ca54d047", size = 12084318, upload-time = "2026-04-23T15:37:41.093Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/fd/6d7b2088180624e3c6dd9471788ac277b9ae3091a4da1b23a191c8ed6419/zensical-0.0.36-cp310-abi3-win_amd64.whl", hash = "sha256:be08cdf13599cfa92d71563ec12058ab20f234ed5489293b83b0f29563cc588a", size = 12301398, upload-time = "2026-04-23T15:37:44.07Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request performs a significant refactor to centralize and decouple the data models used for Borg backup operations. The main change is the extraction of all Pydantic models related to Borg repositories, archives, and diffs into a new module, `borg_models.py`. This improves code organization, reusability, and type clarity across the codebase. Additionally, there are some improvements to the archive comparison TUI feature, including the addition of a new `ComparePathIndex` class for more efficient path indexing and lazy tree hydration.

**Refactoring and Code Organization:**

* All Pydantic models related to Borg (such as `RepoInfo`, `ArchiveInfo`, `DiffResult`, etc.) have been moved from `borg.py` into a new module, `borg_models.py`, and all imports throughout the codebase have been updated accordingly. This decouples data models from implementation logic and improves maintainability. [[1]](diffhunk://#diff-c61d8bb940566275c6d6a454ada020d9ea178bc315f73fcddd36e6aa827c8f33L3-R53) [[2]](diffhunk://#diff-c61d8bb940566275c6d6a454ada020d9ea178bc315f73fcddd36e6aa827c8f33L164-L233) [[3]](diffhunk://#diff-c61d8bb940566275c6d6a454ada020d9ea178bc315f73fcddd36e6aa827c8f33L581-L592) [[4]](diffhunk://#diff-c61d8bb940566275c6d6a454ada020d9ea178bc315f73fcddd36e6aa827c8f33L607-L642) [[5]](diffhunk://#diff-243f4b87bd4b665a86daf9a2fd3275a2c62a31d2b819cb6103cd36cfdba76bbcR1-R125) [[6]](diffhunk://#diff-f367a16f0120d0fd8048bb26d47f1e25a2e08efb5a11349b6dc38b56da573a44L18-R18) [[7]](diffhunk://#diff-eb12bb3d21f50ee1e2a22efb7033feeef4b4ac0750d5e3d35e4e1d26a32631fdL20-R20) [[8]](diffhunk://#diff-f7813bc813539a6cf2cdf8aee44982429855f3f08c20f6e2a3717aecef1be4c5L17-R18) [[9]](diffhunk://#diff-30aa0601af2a562fca904b57c8ef68bd4f1ff2f01b18dd68981207147aca7cc2L8-R8) [[10]](diffhunk://#diff-cadf24ace382d112ab3a8d3b8e1fefb7f429dd8bef323d3ce773e44c039fbf94L8-R8) [[11]](diffhunk://#diff-452425ec1de4a8a26937acb778b5e9a701b7879741322c6c17c9f91ffc53f32eL14-R14) [[12]](diffhunk://#diff-3c1bf02bf2139b77f7cd2b027517240a0cad191ecf814a432d00cd09b0256493L9-R9)

* The DynamoDB client now uses the new `BorgClient` interface instead of directly calling functions from `borg.py`, and uses a helper to instantiate the client. [[1]](diffhunk://#diff-bce461c8ee6bafd447121bacf1823181834b98fed477f1d7b4459c79148b3c50L11-R11) [[2]](diffhunk://#diff-bce461c8ee6bafd447121bacf1823181834b98fed477f1d7b4459c79148b3c50R22-R25) [[3]](diffhunk://#diff-bce461c8ee6bafd447121bacf1823181834b98fed477f1d7b4459c79148b3c50L133-R137) [[4]](diffhunk://#diff-bce461c8ee6bafd447121bacf1823181834b98fed477f1d7b4459c79148b3c50L401-R405)

**Archive Compare TUI Improvements:**

* Introduced `ComparePathIndex`, a new dataclass for efficiently indexing and filtering paths for the archive compare tree, improving lazy hydration and filtering performance. [[1]](diffhunk://#diff-c8348de440438b946c49173d32d780e3b3c40e083b5e93237e64a515a4ec6508R7) [[2]](diffhunk://#diff-c8348de440438b946c49173d32d780e3b3c40e083b5e93237e64a515a4ec6508R18) [[3]](diffhunk://#diff-a9f0a9017d8e811809442a68fc8c7514bdcca8f27d7004c73614f542e27edf03R65-R114)

* Refactored `CompareDirectoryTree` to use an in-memory tree (`Tree[CompareTreeEntry]`) instead of `DirectoryTree`, enabling better control over node metadata and lazy loading.

* Minor import cleanups and optimizations in the TUI compare screen module. [[1]](diffhunk://#diff-a9f0a9017d8e811809442a68fc8c7514bdcca8f27d7004c73614f542e27edf03L5-R13) [[2]](diffhunk://#diff-a9f0a9017d8e811809442a68fc8c7514bdcca8f27d7004c73614f542e27edf03L24) [[3]](diffhunk://#diff-a9f0a9017d8e811809442a68fc8c7514bdcca8f27d7004c73614f542e27edf03L34-R34)
