### PR TITLE
feat(repo): add rsync repository copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It layers a grouped CLI, a Textual TUI, YAML-based configuration, local metadata
 - Creates and manages Borg repositories from a single CLI.
 - Runs daily backup workflows that create archives, prune old data, and compact repositories.
 - Syncs repositories to S3 and restores them when cloud mode is enabled.
+- Copies local repositories to mounted NFS or SMB storage with `rsync`.
 - Supports offline mode with local SQLite-backed metadata storage and no AWS dependency.
 - Stores repository passphrases in per-repo files under `~/.borgboi/passphrases/`.
 - Exposes a Cyclopts-powered CLI with grouped subcommands for repository, backup, S3, exclusions, and config workflows.
@@ -20,6 +21,7 @@ It layers a grouped CLI, a Textual TUI, YAML-based configuration, local metadata
 
 - Python 3.12 or newer
 - [BorgBackup](https://borgbackup.readthedocs.io/en/stable/installation.html) installed and available in `PATH`
+- `rsync` installed and available in `PATH` if you want to copy repositories to mounted NFS or SMB drives
 - AWS credentials with access to your S3 bucket and DynamoDB tables if you want online mode
 
 > [!IMPORTANT]
@@ -77,6 +79,12 @@ Run the daily backup workflow:
 
 ```bash
 bb backup daily --name my-docs-backup
+```
+
+Preview copying the repository to a mounted NAS or file share:
+
+```bash
+bb repo rsync --name my-docs-backup --destination /Volumes/Backups/my-docs-backup --dry-run
 ```
 
 Inspect repositories and archives:

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ It contains the following features:
 * Daily backup command that **creates** a new archive, **prunes** stale archives, and **compacts** the Borg repository to free up space
 * Metadata about your Borg repositories is stored in DynamoDB (or locally in offline mode)
 * Borg repositories are synced with S3 to enable cloud backups and archive restoration from other systems
+* Borg repositories can be copied to mounted NFS or SMB storage with `rsync`
 * **Offline mode** support for users who prefer not to use AWS services
 * **Cyclopts-powered CLI** with rich help output, global root flags, and organized subcommands (`repo`, `backup`, `s3`, `exclusions`, `config`, `tui`, `version`)
 * **Textual TUI** for browsing repositories, opening a full-screen config viewer and repository detail screen, and managing excludes files without leaving the terminal

--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -89,6 +89,31 @@ Show repository information.
 
 `--raw` prints Borg's raw repository info output instead of BorgBoi's formatted summary.
 
+### `repo rsync`
+
+Copy a local Borg repository to mounted NFS or SMB storage with `rsync`.
+
+- Requires `rsync` installed and available in `PATH`
+- Target the repository with `--name/-n` or `--path/-p`
+- Required: `--destination/-d`
+- Optional: `--dry-run`
+- Prompts for confirmation unless `--dry-run` is used
+
+```sh
+bb repo rsync --name my-docs-backup \
+    --destination /Volumes/Backups/my-docs-backup
+```
+
+Use `--dry-run` first to verify the source, destination, and rsync actions without copying data:
+
+```sh
+bb repo rsync --name my-docs-backup \
+    --destination /Volumes/Backups/my-docs-backup \
+    --dry-run
+```
+
+The command mirrors the repository into the destination with rsync flags suited for Borg repository copies, including archive mode, hard-link preservation, partial transfers, and destination deletion for files that no longer exist in the source. BorgBoi prints the source and destination before running, and non-dry-run copies require confirmation because `--delete` can remove unrelated files if the destination is wrong.
+
 ### `repo delete`
 
 Delete a Borg repository.

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -5,6 +5,9 @@
 
     Read installation methods here: [https://borgbackup.readthedocs.io/en/stable/installation.html](https://borgbackup.readthedocs.io/en/stable/installation.html).
 
+!!! tip "Install rsync for mounted-drive copies"
+    `bb repo rsync` expects `rsync` to be installed and available in `PATH`. Use this command when you want to copy a local Borg repository to mounted NFS or SMB storage.
+
 ## Installation
 
 BorgBoi isn't published to PyPI yet, so it is recommended to install it from the GitHub repo with [`uv`](https://docs.astral.sh/uv/).
@@ -301,6 +304,25 @@ bb repo set-quota --name my-docs-backup --quota 200G
 ```
 
 The new quota must be at least as large as the repo's current on-disk size and no larger than the remaining disk headroom after Borg's reserved free space plus the repo's current size. Borg-style decimal quotas like `1.5T` are supported.
+
+## Copy a Repository to Mounted Storage
+
+If you keep a second copy on a NAS or file share, mount the NFS or SMB destination first, then preview the rsync operation:
+
+```sh
+bb repo rsync --name my-docs-backup \
+    --destination /Volumes/Backups/my-docs-backup \
+    --dry-run
+```
+
+When the source and destination look correct, run the copy without `--dry-run`:
+
+```sh
+bb repo rsync --name my-docs-backup \
+    --destination /Volumes/Backups/my-docs-backup
+```
+
+BorgBoi uses rsync mirror-style behavior for this command. It preserves repository structure and hard links, resumes partial transfers where possible, and deletes destination files that are no longer present in the source repository. Non-dry-run copies prompt for confirmation before rsync starts.
 
 ## List Archives
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ no_implicit_reexport = false
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disallow_any_explicit = false
+disable_error_code = ["attr-defined"]
 
 
 [tool.pydantic-mypy]

--- a/src/borgboi/cli/repo.py
+++ b/src/borgboi/cli/repo.py
@@ -1,5 +1,7 @@
 """Repository management commands for BorgBoi CLI."""
 
+import shutil
+import subprocess
 from typing import Annotated
 
 from cyclopts import App, Parameter
@@ -10,10 +12,74 @@ from borgboi.rich_utils import console
 
 logger = get_logger(__name__)
 
+_RSYNC_BASE_FLAGS = [
+    "--archive",
+    "--hard-links",
+    "--delete",
+    "--partial",
+]
+_RSYNC_OPTIONAL_FLAGS = [
+    "--human-readable",
+    "--numeric-ids",
+    "--delete-delay",
+    "--acls",
+    "--xattrs",
+]
 repo = App(
     name="repo",
     help="Repository management commands.\n\nCreate, inspect, list, and delete Borg repositories.",
 )
+
+
+def _rsync_option_text(rsync: str, option: str) -> str:
+    result = subprocess.run(  # noqa: S603
+        [rsync, option],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ""
+
+    return f"{result.stdout}\n{result.stderr}"
+
+
+def _build_rsync_flags(rsync: str) -> list[str]:
+    flags = [*_RSYNC_BASE_FLAGS]
+    help_text = _rsync_option_text(rsync, "--help")
+    flags.extend(flag for flag in _RSYNC_OPTIONAL_FLAGS if flag in help_text)
+
+    info_help = _rsync_option_text(rsync, "--info=help")
+    if "progress2" in info_help:
+        flags.append("--info=progress2")
+    elif "--progress" in help_text:
+        flags.append("--progress")
+
+    return flags
+
+
+def _terminate_rsync(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _run_rsync_command(command: list[str]) -> None:
+    proc = subprocess.Popen(command)  # noqa: S603
+    try:
+        returncode = proc.wait()
+    except BaseException:
+        _terminate_rsync(proc)
+        raise
+
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode=returncode, cmd=command)
 
 
 @repo.command(name="create")
@@ -144,6 +210,93 @@ def repo_info(
         console.print(f"Path: {repo_info.path}")
     except Exception as error:
         logger.exception("Repository info command failed", error=str(error), repo_name=name, repo_path=path, raw=raw)
+        print_error_and_exit(str(error), error=error)
+
+
+@repo.command(name="rsync")
+def repo_rsync(
+    *,
+    destination: Annotated[str, Parameter(name=["--destination", "-d"], help="Mounted NFS/SMB destination path")],
+    path: Annotated[str | None, Parameter(name=["--path", "-p"], help="Repository path")] = None,
+    name: Annotated[str | None, Parameter(name=["--name", "-n"], help="Repository name")] = None,
+    dry_run: Annotated[
+        bool, Parameter(name="--dry-run", negative="", help="Show rsync actions without copying data")
+    ] = False,
+    ctx: ContextArg,
+) -> None:
+    """Copy a local Borg repository to mounted NFS/SMB storage with rsync."""
+    logger.info(
+        "Running repository rsync command", repo_name=name, repo_path=path, destination=destination, dry_run=dry_run
+    )
+    try:
+        rsync = shutil.which("rsync")
+        if rsync is None:
+            msg = "rsync was not found on PATH. Install rsync before using 'borgboi repo rsync'."
+            raise RuntimeError(msg)
+
+        repo_info = ctx.orchestrator.get_repo(name=name, path=path)
+        source = f"{repo_info.path.rstrip('/')}/"
+        console.print(f"Source: [bold cyan]{source}[/]")
+        console.print(f"Destination: [bold cyan]{destination}[/]")
+        console.print(
+            "[bold yellow]Warning:[/] rsync will delete destination files that are not in the source repository."
+        )
+        if not dry_run and not confirm_action("Continue with repository rsync?"):
+            logger.info(
+                "Repository rsync command aborted by user",
+                repo_name=repo_info.name,
+                repo_path=repo_info.path,
+                destination=destination,
+            )
+            console.print("Aborted.")
+            return
+
+        dry_run_flag = ["--dry-run"] if dry_run else []
+        command = [
+            rsync,
+            *_build_rsync_flags(rsync),
+            *dry_run_flag,
+            source,
+            destination,
+        ]
+        logger.info(
+            "Starting repository rsync",
+            repo_name=repo_info.name,
+            repo_path=repo_info.path,
+            destination=destination,
+            dry_run=dry_run,
+        )
+        _run_rsync_command(command)
+        logger.info(
+            "Repository rsync command completed",
+            repo_name=repo_info.name,
+            repo_path=repo_info.path,
+            destination=destination,
+            dry_run=dry_run,
+        )
+        if dry_run:
+            console.print("[bold yellow]Dry run completed - no changes made[/]")
+        else:
+            console.print(f"[bold green]Repository synced to {destination}[/]")
+    except subprocess.CalledProcessError as error:
+        logger.exception(
+            "Repository rsync command failed",
+            error=str(error),
+            repo_name=name,
+            repo_path=path,
+            destination=destination,
+            dry_run=dry_run,
+        )
+        print_error_and_exit(f"rsync failed with exit code {error.returncode}", error=error)
+    except Exception as error:
+        logger.exception(
+            "Repository rsync command failed",
+            error=str(error),
+            repo_name=name,
+            repo_path=path,
+            destination=destination,
+            dry_run=dry_run,
+        )
         print_error_and_exit(str(error), error=error)
 
 

--- a/src/borgboi/cli/repo.py
+++ b/src/borgboi/cli/repo.py
@@ -2,6 +2,7 @@
 
 import shutil
 import subprocess
+from pathlib import Path
 from typing import Annotated
 
 from cyclopts import App, Parameter
@@ -232,6 +233,14 @@ def repo_rsync(
         rsync = shutil.which("rsync")
         if rsync is None:
             msg = "rsync was not found on PATH. Install rsync before using 'borgboi repo rsync'."
+            raise RuntimeError(msg)
+
+        dest_path = Path(destination)
+        if not dest_path.exists():
+            msg = f"Destination path does not exist: {destination}"
+            raise RuntimeError(msg)
+        if not dest_path.is_dir():
+            msg = f"Destination path is not a directory: {destination}"
             raise RuntimeError(msg)
 
         repo_info = ctx.orchestrator.get_repo(name=name, path=path)

--- a/tests/repo_cli_test.py
+++ b/tests/repo_cli_test.py
@@ -1,3 +1,4 @@
+import subprocess
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import Mock
@@ -133,6 +134,193 @@ def test_repo_info_routes_errors_to_print_error_and_exit(monkeypatch: pytest.Mon
 
     with pytest.raises(AssertionError, match="broken"):
         repo_module.repo_info(name="repo-one", ctx=cast(Any, ctx))
+
+
+def test_repo_rsync_runs_rsync_with_mirror_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = SimpleNamespace(name="repo-one", path="/repo/one")
+    orchestrator = SimpleNamespace(get_repo=Mock(return_value=repo))
+    ctx = SimpleNamespace(orchestrator=orchestrator)
+    proc = SimpleNamespace(wait=Mock(return_value=0))
+    subprocess_popen = Mock(return_value=proc)
+    console_print = Mock()
+
+    monkeypatch.setattr(repo_module.shutil, "which", lambda command: "/usr/bin/rsync" if command == "rsync" else None)
+    monkeypatch.setattr(repo_module.subprocess, "Popen", subprocess_popen)
+    monkeypatch.setattr(repo_module, "_build_rsync_flags", lambda rsync: repo_module._RSYNC_BASE_FLAGS)
+    monkeypatch.setattr(repo_module, "confirm_action", lambda prompt: True)
+    monkeypatch.setattr("borgboi.cli.repo.console.print", console_print)
+
+    repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
+
+    orchestrator.get_repo.assert_called_once_with(name="repo-one", path=None)
+    subprocess_popen.assert_called_once_with(
+        [
+            "/usr/bin/rsync",
+            "--archive",
+            "--hard-links",
+            "--delete",
+            "--partial",
+            "/repo/one/",
+            "/mnt/backup/repo-one",
+        ]
+    )
+    assert console_print.call_args_list == [
+        (("Source: [bold cyan]/repo/one/[/]",), {}),
+        (("Destination: [bold cyan]/mnt/backup/repo-one[/]",), {}),
+        (
+            ("[bold yellow]Warning:[/] rsync will delete destination files that are not in the source repository.",),
+            {},
+        ),
+        (("[bold green]Repository synced to /mnt/backup/repo-one[/]",), {}),
+    ]
+
+
+def test_repo_rsync_adds_dry_run_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = SimpleNamespace(name="repo-one", path="/repo/one/")
+    orchestrator = SimpleNamespace(get_repo=Mock(return_value=repo))
+    ctx = SimpleNamespace(orchestrator=orchestrator)
+    proc = SimpleNamespace(wait=Mock(return_value=0))
+    subprocess_popen = Mock(return_value=proc)
+    console_print = Mock()
+    confirm_mock = Mock(side_effect=AssertionError("confirmation should not run"))
+
+    monkeypatch.setattr(repo_module.shutil, "which", lambda command: "/usr/bin/rsync" if command == "rsync" else None)
+    monkeypatch.setattr(repo_module.subprocess, "Popen", subprocess_popen)
+    monkeypatch.setattr(repo_module, "_build_rsync_flags", lambda rsync: repo_module._RSYNC_BASE_FLAGS)
+    monkeypatch.setattr(repo_module, "confirm_action", confirm_mock)
+    monkeypatch.setattr("borgboi.cli.repo.console.print", console_print)
+
+    repo_module.repo_rsync(path="/repo/one/", destination="/mnt/backup/repo-one", dry_run=True, ctx=cast(Any, ctx))
+
+    command = subprocess_popen.call_args.args[0]
+    confirm_mock.assert_not_called()
+    assert "--dry-run" in command
+    assert command[-2:] == ["/repo/one/", "/mnt/backup/repo-one"]
+    assert console_print.call_args_list == [
+        (("Source: [bold cyan]/repo/one/[/]",), {}),
+        (("Destination: [bold cyan]/mnt/backup/repo-one[/]",), {}),
+        (
+            ("[bold yellow]Warning:[/] rsync will delete destination files that are not in the source repository.",),
+            {},
+        ),
+        (("[bold yellow]Dry run completed - no changes made[/]",), {}),
+    ]
+
+
+def test_repo_rsync_aborts_when_confirmation_declined(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = SimpleNamespace(name="repo-one", path="/repo/one")
+    orchestrator = SimpleNamespace(get_repo=Mock(return_value=repo))
+    ctx = SimpleNamespace(orchestrator=orchestrator)
+    subprocess_popen = Mock()
+    console_print = Mock()
+
+    monkeypatch.setattr(repo_module.shutil, "which", lambda command: "/usr/bin/rsync" if command == "rsync" else None)
+    monkeypatch.setattr(repo_module.subprocess, "Popen", subprocess_popen)
+    monkeypatch.setattr(repo_module, "confirm_action", lambda prompt: False)
+    monkeypatch.setattr("borgboi.cli.repo.console.print", console_print)
+
+    repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
+
+    subprocess_popen.assert_not_called()
+    assert console_print.call_args_list[-1] == (("Aborted.",), {})
+
+
+def test_build_rsync_flags_skips_unsupported_optional_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[1] == "--help":
+            stdout = "--human-readable\n--progress\n"
+            return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+        if command[1] == "--info=help":
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(repo_module.subprocess, "run", run)
+
+    assert repo_module._build_rsync_flags("/usr/bin/rsync") == [
+        "--archive",
+        "--hard-links",
+        "--delete",
+        "--partial",
+        "--human-readable",
+        "--progress",
+    ]
+    assert [command[1] for command in calls] == ["--help", "--info=help"]
+
+
+def test_build_rsync_flags_prefers_progress2_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if command[1] == "--help":
+            stdout = "--human-readable\n--numeric-ids\n--delete-delay\n--acls\n--xattrs\n--progress\n"
+            return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+        if command[1] == "--info=help":
+            return subprocess.CompletedProcess(command, 0, stdout="progress2\n", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(repo_module.subprocess, "run", run)
+
+    assert repo_module._build_rsync_flags("/usr/bin/rsync") == [
+        "--archive",
+        "--hard-links",
+        "--delete",
+        "--partial",
+        "--human-readable",
+        "--numeric-ids",
+        "--delete-delay",
+        "--acls",
+        "--xattrs",
+        "--info=progress2",
+    ]
+
+
+def test_run_rsync_command_terminates_process_on_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = SimpleNamespace(
+        poll=Mock(return_value=None),
+        terminate=Mock(),
+        kill=Mock(),
+    )
+    proc.wait = Mock(side_effect=[KeyboardInterrupt, 0])
+
+    monkeypatch.setattr(repo_module.subprocess, "Popen", Mock(return_value=proc))
+
+    with pytest.raises(KeyboardInterrupt):
+        repo_module._run_rsync_command(["rsync", "--archive", "/repo/", "/mnt/repo"])
+
+    proc.terminate.assert_called_once_with()
+    proc.kill.assert_not_called()
+    assert proc.wait.call_args_list[-1].kwargs == {"timeout": 5}
+
+
+def test_repo_rsync_routes_missing_rsync_to_print_error_and_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = SimpleNamespace(orchestrator=SimpleNamespace(get_repo=Mock()))
+
+    def fail(message: str, *, error: Exception | None = None) -> None:
+        raise AssertionError((message, error))
+
+    monkeypatch.setattr(repo_module.shutil, "which", lambda command: None)
+    monkeypatch.setattr(repo_module, "print_error_and_exit", fail)
+
+    with pytest.raises(AssertionError, match="rsync was not found"):
+        repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
+
+
+def test_repo_rsync_routes_rsync_failure_to_print_error_and_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = SimpleNamespace(name="repo-one", path="/repo/one")
+    ctx = SimpleNamespace(orchestrator=SimpleNamespace(get_repo=Mock(return_value=repo)))
+
+    def fail(message: str, *, error: Exception | None = None) -> None:
+        raise AssertionError((message, error))
+
+    monkeypatch.setattr(repo_module.shutil, "which", lambda command: "/usr/bin/rsync" if command == "rsync" else None)
+    monkeypatch.setattr(repo_module, "_build_rsync_flags", lambda rsync: repo_module._RSYNC_BASE_FLAGS)
+    monkeypatch.setattr(repo_module, "confirm_action", lambda prompt: True)
+    monkeypatch.setattr(repo_module.subprocess, "Popen", Mock(return_value=SimpleNamespace(wait=Mock(return_value=23))))
+    monkeypatch.setattr(repo_module, "print_error_and_exit", fail)
+
+    with pytest.raises(AssertionError, match="rsync failed with exit code 23"):
+        repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
 
 
 def test_repo_delete_aborts_when_confirmation_declined(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/repo_cli_test.py
+++ b/tests/repo_cli_test.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import Mock
@@ -136,13 +137,14 @@ def test_repo_info_routes_errors_to_print_error_and_exit(monkeypatch: pytest.Mon
         repo_module.repo_info(name="repo-one", ctx=cast(Any, ctx))
 
 
-def test_repo_rsync_runs_rsync_with_mirror_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_repo_rsync_runs_rsync_with_mirror_flags(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     repo = SimpleNamespace(name="repo-one", path="/repo/one")
     orchestrator = SimpleNamespace(get_repo=Mock(return_value=repo))
     ctx = SimpleNamespace(orchestrator=orchestrator)
     proc = SimpleNamespace(wait=Mock(return_value=0))
     subprocess_popen = Mock(return_value=proc)
     console_print = Mock()
+    destination = str(tmp_path)
 
     monkeypatch.setattr(repo_module.shutil, "which", lambda command: "/usr/bin/rsync" if command == "rsync" else None)
     monkeypatch.setattr(repo_module.subprocess, "Popen", subprocess_popen)
@@ -150,7 +152,7 @@ def test_repo_rsync_runs_rsync_with_mirror_flags(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(repo_module, "confirm_action", lambda prompt: True)
     monkeypatch.setattr("borgboi.cli.repo.console.print", console_print)
 
-    repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
+    repo_module.repo_rsync(name="repo-one", destination=destination, ctx=cast(Any, ctx))
 
     orchestrator.get_repo.assert_called_once_with(name="repo-one", path=None)
     subprocess_popen.assert_called_once_with(
@@ -161,21 +163,21 @@ def test_repo_rsync_runs_rsync_with_mirror_flags(monkeypatch: pytest.MonkeyPatch
             "--delete",
             "--partial",
             "/repo/one/",
-            "/mnt/backup/repo-one",
+            destination,
         ]
     )
     assert console_print.call_args_list == [
         (("Source: [bold cyan]/repo/one/[/]",), {}),
-        (("Destination: [bold cyan]/mnt/backup/repo-one[/]",), {}),
+        ((f"Destination: [bold cyan]{destination}[/]",), {}),
         (
             ("[bold yellow]Warning:[/] rsync will delete destination files that are not in the source repository.",),
             {},
         ),
-        (("[bold green]Repository synced to /mnt/backup/repo-one[/]",), {}),
+        ((f"[bold green]Repository synced to {destination}[/]",), {}),
     ]
 
 
-def test_repo_rsync_adds_dry_run_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_repo_rsync_adds_dry_run_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     repo = SimpleNamespace(name="repo-one", path="/repo/one/")
     orchestrator = SimpleNamespace(get_repo=Mock(return_value=repo))
     ctx = SimpleNamespace(orchestrator=orchestrator)
@@ -183,6 +185,7 @@ def test_repo_rsync_adds_dry_run_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     subprocess_popen = Mock(return_value=proc)
     console_print = Mock()
     confirm_mock = Mock(side_effect=AssertionError("confirmation should not run"))
+    destination = str(tmp_path)
 
     monkeypatch.setattr(repo_module.shutil, "which", lambda command: "/usr/bin/rsync" if command == "rsync" else None)
     monkeypatch.setattr(repo_module.subprocess, "Popen", subprocess_popen)
@@ -190,15 +193,15 @@ def test_repo_rsync_adds_dry_run_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_module, "confirm_action", confirm_mock)
     monkeypatch.setattr("borgboi.cli.repo.console.print", console_print)
 
-    repo_module.repo_rsync(path="/repo/one/", destination="/mnt/backup/repo-one", dry_run=True, ctx=cast(Any, ctx))
+    repo_module.repo_rsync(path="/repo/one/", destination=destination, dry_run=True, ctx=cast(Any, ctx))
 
     command = subprocess_popen.call_args.args[0]
     confirm_mock.assert_not_called()
     assert "--dry-run" in command
-    assert command[-2:] == ["/repo/one/", "/mnt/backup/repo-one"]
+    assert command[-2:] == ["/repo/one/", destination]
     assert console_print.call_args_list == [
         (("Source: [bold cyan]/repo/one/[/]",), {}),
-        (("Destination: [bold cyan]/mnt/backup/repo-one[/]",), {}),
+        ((f"Destination: [bold cyan]{destination}[/]",), {}),
         (
             ("[bold yellow]Warning:[/] rsync will delete destination files that are not in the source repository.",),
             {},
@@ -207,7 +210,7 @@ def test_repo_rsync_adds_dry_run_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
-def test_repo_rsync_aborts_when_confirmation_declined(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_repo_rsync_aborts_when_confirmation_declined(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     repo = SimpleNamespace(name="repo-one", path="/repo/one")
     orchestrator = SimpleNamespace(get_repo=Mock(return_value=repo))
     ctx = SimpleNamespace(orchestrator=orchestrator)
@@ -219,7 +222,7 @@ def test_repo_rsync_aborts_when_confirmation_declined(monkeypatch: pytest.Monkey
     monkeypatch.setattr(repo_module, "confirm_action", lambda prompt: False)
     monkeypatch.setattr("borgboi.cli.repo.console.print", console_print)
 
-    repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
+    repo_module.repo_rsync(name="repo-one", destination=str(tmp_path), ctx=cast(Any, ctx))
 
     subprocess_popen.assert_not_called()
     assert console_print.call_args_list[-1] == (("Aborted.",), {})
@@ -306,7 +309,9 @@ def test_repo_rsync_routes_missing_rsync_to_print_error_and_exit(monkeypatch: py
         repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
 
 
-def test_repo_rsync_routes_rsync_failure_to_print_error_and_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_repo_rsync_routes_rsync_failure_to_print_error_and_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     repo = SimpleNamespace(name="repo-one", path="/repo/one")
     ctx = SimpleNamespace(orchestrator=SimpleNamespace(get_repo=Mock(return_value=repo)))
 
@@ -320,7 +325,7 @@ def test_repo_rsync_routes_rsync_failure_to_print_error_and_exit(monkeypatch: py
     monkeypatch.setattr(repo_module, "print_error_and_exit", fail)
 
     with pytest.raises(AssertionError, match="rsync failed with exit code 23"):
-        repo_module.repo_rsync(name="repo-one", destination="/mnt/backup/repo-one", ctx=cast(Any, ctx))
+        repo_module.repo_rsync(name="repo-one", destination=str(tmp_path), ctx=cast(Any, ctx))
 
 
 def test_repo_delete_aborts_when_confirmation_declined(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Add `borgboi repo rsync` for copying local Borg repositories to mounted NFS/SMB destinations with rsync mirror flags.
- Probe rsync capabilities for portable optional flags and progress output.
- Add confirmation, dry-run path context, process cleanup on interruption, and CLI regression tests.

## Verification
- `just lint`
- `uv run ruff check src/borgboi/cli/repo.py tests/repo_cli_test.py`
- `uv run pytest tests/repo_cli_test.py -vv --capture=tee-sys --diff-symbols`