### PR TITLE
refactor: move storage selection into composition root

### DIFF
--- a/src/borgboi/cli/main.py
+++ b/src/borgboi/cli/main.py
@@ -33,7 +33,13 @@ from borgboi.core.telemetry import (
 )
 from borgboi.rich_utils import console
 
-install(suppress=[cyclopts])
+
+def _should_install_rich_tracebacks() -> bool:
+    return os.environ.get("CI", "").lower() not in {"1", "true", "yes"}
+
+
+if _should_install_rich_tracebacks():
+    install(suppress=[cyclopts])
 
 
 class BorgBoiContext:

--- a/src/borgboi/cli/main.py
+++ b/src/borgboi/cli/main.py
@@ -48,10 +48,26 @@ class BorgBoiContext:
 
     @property
     def orchestrator(self) -> Orchestrator:
+        from borgboi.clients.s3_client import S3Client
         from borgboi.core.orchestrator import Orchestrator
+        from borgboi.storage.base import RepositoryStorage
+        from borgboi.storage.db import init_local_database
 
         if self._orchestrator is None:
-            self._orchestrator = Orchestrator(config=self.config)
+            cfg = self.config
+            storage: RepositoryStorage
+            if cfg.offline:
+                from borgboi.storage.sqlite import SQLiteStorage
+
+                storage = SQLiteStorage()
+                s3_client = None
+            else:
+                from borgboi.storage.dynamodb import DynamoDBStorage
+
+                init_local_database(cfg)
+                storage = DynamoDBStorage(config=cfg)
+                s3_client = S3Client(config=cfg.aws)
+            self._orchestrator = Orchestrator(config=cfg, storage=storage, s3_client=s3_client)
         return self._orchestrator
 
     @property

--- a/src/borgboi/core/logging.py
+++ b/src/borgboi/core/logging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging as stdlib_logging
+import os
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -30,6 +31,7 @@ _LOG_LEVELS = {
     "error": stdlib_logging.ERROR,
     "critical": stdlib_logging.CRITICAL,
 }
+_CI_TRUE_VALUES = {"1", "true", "yes"}
 
 
 class _LoggingState:
@@ -74,6 +76,10 @@ def _configure_structlog() -> None:
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
+
+
+def _is_ci() -> bool:
+    return os.environ.get("CI", "").lower() in _CI_TRUE_VALUES
 
 
 def _build_log_file_name(timestamp: datetime | None = None) -> str:
@@ -153,6 +159,8 @@ def configure_logging(config: Config) -> Path | None:
     _remove_managed_handlers(namespace_logger)
 
     if not config.logging.enabled:
+        if _is_ci():
+            _configure_structlog()
         _LoggingState.active_log_file = None
         namespace_logger.setLevel(stdlib_logging.NOTSET)
         namespace_logger.propagate = True

--- a/src/borgboi/core/orchestrator.py
+++ b/src/borgboi/core/orchestrator.py
@@ -51,26 +51,27 @@ class Orchestrator:
     dependency-injected clients and storage backends.
 
     Example:
-        >>> orchestrator = Orchestrator()
+        >>> orchestrator = Orchestrator(storage=SQLiteStorage())
         >>> repo = orchestrator.create_repo("/path/to/repo", "/home/user", "my-backups")
         >>> orchestrator.backup(repo)
     """
 
     def __init__(
         self,
-        borg_client: BorgClient | None = None,
-        storage: RepositoryStorage | None = None,
-        s3_client: S3ClientInterface | None = None,
+        *,
+        storage: RepositoryStorage,
         config: Config | None = None,
+        borg_client: BorgClient | None = None,
+        s3_client: S3ClientInterface | None = None,
         output_handler: BaseOutputHandler | None = None,
     ) -> None:
-        """Initialize Orchestrator with optional dependencies.
+        """Initialize Orchestrator with injected dependencies.
 
         Args:
-            borg_client: Borg backup client (default: auto-created)
-            storage: Repository storage backend (default: auto-created based on config)
-            s3_client: S3 client for cloud sync (default: None)
+            storage: Repository storage backend (required — supplied by the composition root)
             config: Configuration instance (default: get_config())
+            borg_client: Borg backup client (default: auto-created)
+            s3_client: S3 client for cloud sync (default: None — cloud features disabled)
             output_handler: Handler for output messages (default: DefaultOutputHandler).
                 Handlers may optionally implement `render_command()` for richer
                 streaming output; legacy handlers remain supported.
@@ -78,69 +79,8 @@ class Orchestrator:
         self.config = config or get_config()
         self.output = output_handler or DefaultOutputHandler()
         self.borg = borg_client or create_borg_client(config=self.config)
-        self.storage = storage or self._create_default_storage()
-        self.s3: S3ClientInterface | None = s3_client or self._create_default_s3_client()
-
-    def _create_default_storage(self) -> RepositoryStorage:
-        """Create the default storage backend based on configuration.
-
-        Returns:
-            RepositoryStorage instance (SQLite for offline, DynamoDB for cloud)
-        """
-        if self.config.offline:
-            logger.debug("Creating SQLite storage for offline mode")
-            from borgboi.storage.sqlite import SQLiteStorage
-
-            return SQLiteStorage()
-        else:
-            logger.debug("Creating DynamoDB storage for cloud mode, initializing local SQLite cache")
-            self._ensure_local_sqlite_initialized()
-            from borgboi.storage.dynamodb import DynamoDBStorage
-
-            return DynamoDBStorage(config=self.config)
-
-    def _create_default_s3_client(self) -> S3ClientInterface | None:
-        """Create the default S3 client when cloud features are enabled."""
-        if self.config.offline:
-            logger.debug("Skipping S3 client creation in offline mode")
-            return None
-
-        logger.debug("Creating S3 client for cloud mode")
-        from borgboi.clients.s3_client import S3Client
-
-        return S3Client(config=self.config.aws)
-
-    def _ensure_local_sqlite_initialized(self) -> None:
-        """Initialize local SQLite storage and run migrations.
-
-        This keeps local metadata storage aligned even when cloud storage
-        (DynamoDB) is the active backend.
-        """
-        from borgboi.storage.db import get_db_path
-        from borgboi.storage.sqlite_migration import auto_migrate_if_needed
-
-        db_path = get_db_path()
-        if self._should_log_sqlite_migration(db_path):
-            logger.info("Migrating local metadata database", db_path=str(db_path))
-            self.output.on_log("info", f"Migrating local metadata database to {db_path}")
-        else:
-            logger.debug("No SQLite migration needed", db_path=str(db_path))
-
-        engine = auto_migrate_if_needed(db_path)
-        engine.dispose()
-        logger.debug("Local SQLite database initialized successfully")
-
-    def _should_log_sqlite_migration(self, db_path: Path) -> bool:
-        """Return True when a legacy storage migration is expected."""
-        if db_path.exists():
-            return False
-
-        borgboi_dir = db_path.parent.parent if db_path.parent.name == ".database" else db_path.parent
-
-        legacy_db_path = borgboi_dir / "borgboi.db"
-        legacy_data_path = borgboi_dir / "data"
-        legacy_metadata_path = borgboi_dir / ".borgboi_metadata"
-        return legacy_db_path.exists() or legacy_data_path.exists() or legacy_metadata_path.exists()
+        self.storage = storage
+        self.s3: S3ClientInterface | None = s3_client
 
     # Repository Workflows
 

--- a/src/borgboi/storage/db.py
+++ b/src/borgboi/storage/db.py
@@ -3,6 +3,7 @@
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     BigInteger,
@@ -18,6 +19,13 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 from sqlalchemy.pool import NullPool
+
+from borgboi.core.logging import get_logger
+
+if TYPE_CHECKING:
+    from borgboi.config import Config
+
+logger = get_logger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -125,3 +133,36 @@ def init_db(db_path: Path) -> Engine:
             session.commit()
 
     return engine
+
+
+def init_local_database(config: "Config") -> None:
+    """Ensure the local metadata SQLite database exists and is migrated.
+
+    Idempotent: safe to call multiple times. Logs at info level when a legacy
+    layout will be migrated, debug otherwise. Disposes the engine before
+    returning so callers receive a clean handle through their own storage.
+    """
+    from borgboi.storage.sqlite_migration import auto_migrate_if_needed
+
+    db_path = get_db_path(config.borgboi_dir)
+    if _should_log_sqlite_migration(db_path):
+        logger.info("Migrating local metadata database", db_path=str(db_path))
+    else:
+        logger.debug("No SQLite migration needed", db_path=str(db_path))
+
+    engine = auto_migrate_if_needed(db_path)
+    engine.dispose()
+    logger.debug("Local SQLite database initialized successfully")
+
+
+def _should_log_sqlite_migration(db_path: Path) -> bool:
+    """Return True when a legacy storage migration is expected."""
+    if db_path.exists():
+        return False
+
+    borgboi_dir = db_path.parent.parent if db_path.parent.name == ".database" else db_path.parent
+
+    legacy_db_path = borgboi_dir / "borgboi.db"
+    legacy_data_path = borgboi_dir / "data"
+    legacy_metadata_path = borgboi_dir / ".borgboi_metadata"
+    return legacy_db_path.exists() or legacy_data_path.exists() or legacy_metadata_path.exists()

--- a/src/borgboi/tui/app.py
+++ b/src/borgboi/tui/app.py
@@ -63,9 +63,26 @@ class BorgBoiApp(App[None]):
     def orchestrator(self) -> Orchestrator:
         """Return the shared orchestrator, constructing it lazily if not provided at init."""
         if self._orchestrator is None:
+            from borgboi.clients.s3_client import S3Client
+            from borgboi.config import get_config
             from borgboi.core.orchestrator import Orchestrator
+            from borgboi.storage.base import RepositoryStorage
+            from borgboi.storage.db import init_local_database
 
-            self._orchestrator = Orchestrator(config=self._config)
+            cfg = self._config or get_config()
+            storage: RepositoryStorage
+            if cfg.offline:
+                from borgboi.storage.sqlite import SQLiteStorage
+
+                storage = SQLiteStorage()
+                s3_client = None
+            else:
+                from borgboi.storage.dynamodb import DynamoDBStorage
+
+                init_local_database(cfg)
+                storage = DynamoDBStorage(config=cfg)
+                s3_client = S3Client(config=cfg.aws)
+            self._orchestrator = Orchestrator(config=cfg, storage=storage, s3_client=s3_client)
         return self._orchestrator
 
     @override
@@ -96,6 +113,10 @@ class BorgBoiApp(App[None]):
             },
         )
         logger.info("TUI app mounted", offline=self._config.offline if self._config else None)
+        if self._config is not None:
+            from borgboi.storage.db import init_local_database
+
+            init_local_database(self._config)
         self._main_screen = self.screen
 
         # Mode indicator in header subtitle

--- a/src/borgboi/tui/features/daily_backup/progress.py
+++ b/src/borgboi/tui/features/daily_backup/progress.py
@@ -11,7 +11,7 @@ from typing import Protocol
 from sqlalchemy import Engine, func
 
 from borgboi.core.logging import get_logger
-from borgboi.storage.db import BackupStageTimingRow, get_db_path, get_session_factory, init_db
+from borgboi.storage.db import BackupStageTimingRow, get_session_factory, init_db
 
 logger = get_logger(__name__)
 
@@ -48,8 +48,14 @@ class SQLiteDailyBackupProgressHistory:
     """SQLite-backed stage timing history for TUI daily backup progress."""
 
     def __init__(self, db_path: Path | None = None, engine: Engine | None = None) -> None:
-        self._owns_engine = engine is None
-        self._engine = engine or init_db(db_path or get_db_path())
+        if engine is not None:
+            self._owns_engine = False
+            self._engine = engine
+        else:
+            if db_path is None:
+                raise ValueError("Either db_path or engine must be provided")
+            self._owns_engine = True
+            self._engine = init_db(db_path)
         self._session_factory = get_session_factory(self._engine)
         logger.debug(
             "SQLiteDailyBackupProgressHistory initialized", db_path=str(db_path), owns_engine=self._owns_engine

--- a/src/borgboi/tui/features/daily_backup/screen.py
+++ b/src/borgboi/tui/features/daily_backup/screen.py
@@ -13,6 +13,7 @@ from textual.screen import Screen
 from textual.widgets import Button, Footer, Header, Label, ProgressBar, RichLog, Select, Static, Switch
 
 from borgboi.core.logging import get_logger
+from borgboi.storage.db import get_db_path
 from borgboi.tui.features.daily_backup.output import TuiOutputHandler
 from borgboi.tui.features.daily_backup.progress import SQLiteDailyBackupProgressHistory
 
@@ -170,7 +171,7 @@ class DailyBackupScreen(Screen[None]):
         progress_history: SQLiteDailyBackupProgressHistory | None = None
         progress_history_error: str | None = None
         try:
-            progress_history = SQLiteDailyBackupProgressHistory()
+            progress_history = SQLiteDailyBackupProgressHistory(db_path=get_db_path(orch.config.borgboi_dir))
             logger.debug("Progress history initialized")
         except Exception as exc:
             progress_history_error = str(exc)

--- a/tests/backup_cli_test.py
+++ b/tests/backup_cli_test.py
@@ -122,7 +122,7 @@ def test_backup_run_no_json_passes_options_and_skips_stats(
             raise AssertionError("archive_info should not be called when --no-json is used")
 
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
             self.borg = _FakeBorgClient()
 
@@ -173,7 +173,7 @@ def test_backup_run_default_fetches_stats_and_renders_table(
             return archive_info_result
 
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
             self.borg = _FakeBorgClient()
 
@@ -212,7 +212,7 @@ def test_backup_daily_accepts_repo_name(monkeypatch: pytest.MonkeyPatch) -> None
     fake_repo = SimpleNamespace(name="daily-repo", path="/fake/repo")
 
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def get_repo(self, name: str | None = None, path: str | None = None) -> object:
@@ -236,7 +236,7 @@ def test_backup_daily_name_respects_no_s3_sync_and_passphrase(monkeypatch: pytes
     fake_repo = SimpleNamespace(name="daily-repo", path="/fake/repo")
 
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def get_repo(self, name: str | None = None, path: str | None = None) -> object:
@@ -358,7 +358,7 @@ def test_backup_diff_defaults_to_two_most_recent_archives(
     fake_result = DiffResult.model_validate({"archive1": "archive-1", "archive2": "archive-2", "entries": []})
 
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def get_repo(self, name: str | None = None, path: str | None = None) -> object:
@@ -411,7 +411,7 @@ def test_backup_diff_passes_explicit_archives_and_filters(
     )
 
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def get_repo(self, name: str | None = None, path: str | None = None) -> object:
@@ -467,7 +467,7 @@ def test_backup_diff_passes_explicit_archives_and_filters(
 
 def test_backup_diff_requires_both_explicit_archives(capsys: pytest.CaptureFixture[str]) -> None:
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def get_repo(self, name: str | None = None, path: str | None = None) -> object:

--- a/tests/backup_cli_test.py
+++ b/tests/backup_cli_test.py
@@ -147,7 +147,7 @@ def test_backup_run_no_json_passes_options_and_skips_stats(
     monkeypatch.setattr("borgboi.core.orchestrator.Orchestrator", _FakeOrchestrator)
     monkeypatch.setattr("borgboi.cli.backup._render_archive_stats_table", lambda *args: render_calls.append(args))
 
-    exit_code = invoke_cli(cli_main.cli, ["backup", "run", "--path", str(tmp_path), "--no-json"])
+    exit_code = invoke_cli(cli_main.cli, ["--offline", "backup", "run", "--path", str(tmp_path), "--no-json"])
 
     assert exit_code == 0
     assert len(captured_options) == 1
@@ -198,7 +198,7 @@ def test_backup_run_default_fetches_stats_and_renders_table(
     monkeypatch.setattr("borgboi.core.orchestrator.Orchestrator", _FakeOrchestrator)
     monkeypatch.setattr("borgboi.cli.backup._render_archive_stats_table", lambda *args: render_calls.append(args))
 
-    exit_code = invoke_cli(cli_main.cli, ["backup", "run", "--path", str(tmp_path)])
+    exit_code = invoke_cli(cli_main.cli, ["--offline", "backup", "run", "--path", str(tmp_path)])
 
     assert exit_code == 0
     assert captured_options == [None]
@@ -224,7 +224,7 @@ def test_backup_daily_accepts_repo_name(monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr("borgboi.core.orchestrator.Orchestrator", _FakeOrchestrator)
 
-    exit_code = invoke_cli(cli_main.cli, ["backup", "daily", "--name", "daily-repo"])
+    exit_code = invoke_cli(cli_main.cli, ["--offline", "backup", "daily", "--name", "daily-repo"])
 
     assert exit_code == 0
     assert get_repo_calls == [("daily-repo", None)]
@@ -250,7 +250,7 @@ def test_backup_daily_name_respects_no_s3_sync_and_passphrase(monkeypatch: pytes
 
     exit_code = invoke_cli(
         cli_main.cli,
-        ["backup", "daily", "--name", "daily-repo", "--passphrase", "cli-passphrase", "--no-s3-sync"],
+        ["--offline", "backup", "daily", "--name", "daily-repo", "--passphrase", "cli-passphrase", "--no-s3-sync"],
     )
 
     assert exit_code == 0
@@ -385,7 +385,7 @@ def test_backup_diff_defaults_to_two_most_recent_archives(
 
     monkeypatch.setattr("borgboi.core.orchestrator.Orchestrator", _FakeOrchestrator)
 
-    exit_code = invoke_cli(cli_main.cli, ["backup", "diff", "--name", "demo-repo"])
+    exit_code = invoke_cli(cli_main.cli, ["--offline", "backup", "diff", "--name", "demo-repo"])
     captured = capsys.readouterr()
 
     assert exit_code == 0
@@ -437,6 +437,7 @@ def test_backup_diff_passes_explicit_archives_and_filters(
     exit_code = invoke_cli(
         cli_main.cli,
         [
+            "--offline",
             "backup",
             "diff",
             "--name",
@@ -477,7 +478,10 @@ def test_backup_diff_requires_both_explicit_archives(capsys: pytest.CaptureFixtu
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr("borgboi.core.orchestrator.Orchestrator", _FakeOrchestrator)
 
-    exit_code = invoke_cli(cli_main.cli, ["backup", "diff", "--name", "demo-repo", "--archive1", "archive-a"])
+    exit_code = invoke_cli(
+        cli_main.cli,
+        ["--offline", "backup", "diff", "--name", "demo-repo", "--archive1", "archive-a"],
+    )
     try:
         captured = capsys.readouterr()
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -67,7 +67,7 @@ def test_repo_create(
     backup_target_dir: Path,
 ) -> None:
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def create_repo(
@@ -110,7 +110,7 @@ def test_root_offline_flag_is_accepted(capsys: pytest.CaptureFixture[str]) -> No
 
 def test_cli_logging_redacts_passphrase_tokens(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def create_repo(
@@ -161,7 +161,7 @@ def test_repo_create_logs_structured_cli_events(monkeypatch: pytest.MonkeyPatch,
     home_dir = tmp_path / "home"
 
     class _FakeOrchestrator:
-        def __init__(self, config: object) -> None:
+        def __init__(self, config: object, **_: object) -> None:
             del config
 
         def create_repo(

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -61,6 +61,19 @@ def test_package_exports_root_app() -> None:
     assert cli_package.cli is cli_main.cli
 
 
+@pytest.mark.parametrize("ci_value", ["1", "true", "TRUE", "yes"])
+def test_rich_tracebacks_are_disabled_in_ci(monkeypatch: pytest.MonkeyPatch, ci_value: str) -> None:
+    monkeypatch.setenv("CI", ci_value)
+
+    assert not cli_main._should_install_rich_tracebacks()
+
+
+def test_rich_tracebacks_are_enabled_outside_ci(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CI", raising=False)
+
+    assert cli_main._should_install_rich_tracebacks()
+
+
 def test_repo_create(
     monkeypatch: pytest.MonkeyPatch,
     repo_storage_dir: Path,

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -99,6 +99,7 @@ def test_repo_create(
     exit_code = invoke_cli(
         cli_main.cli,
         [
+            "--offline",
             "repo",
             "create",
             "--path",
@@ -146,6 +147,7 @@ def test_cli_logging_redacts_passphrase_tokens(monkeypatch: pytest.MonkeyPatch, 
     exit_code = invoke_cli(
         cli_main.cli,
         [
+            "--offline",
             "repo",
             "create",
             "--path",
@@ -199,6 +201,7 @@ def test_repo_create_logs_structured_cli_events(monkeypatch: pytest.MonkeyPatch,
     exit_code = invoke_cli(
         cli_main.cli,
         [
+            "--offline",
             "repo",
             "create",
             "--path",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,8 +220,10 @@ def backup_target_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def _create_test_repo(repo_storage_dir: Path, backup_target_dir: Path, repo_name: str) -> BorgBoiRepo:
     from borgboi.config import Config
     from borgboi.core.orchestrator import Orchestrator
+    from borgboi.storage.dynamodb import DynamoDBStorage
 
-    orchestrator = Orchestrator(config=Config(offline=False))
+    cfg = Config(offline=False)
+    orchestrator = Orchestrator(config=cfg, storage=DynamoDBStorage(config=cfg))
     return orchestrator.create_repo(repo_storage_dir.as_posix(), backup_target_dir.as_posix(), repo_name)
 
 

--- a/tests/core_logging_test.py
+++ b/tests/core_logging_test.py
@@ -49,6 +49,27 @@ def test_configure_logging_disabled_does_not_create_logs_dir() -> None:
     assert not cfg.logs_dir.exists()
 
 
+def test_configure_logging_disabled_in_ci_avoids_rich_exception_tracebacks(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("CI", "true")
+    cfg = Config(logging=LoggingConfig(enabled=False))
+
+    configure_logging(cfg)
+
+    with caplog.at_level(logging.ERROR, logger="borgboi"):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            get_logger("borgboi.test").exception("failed event")
+
+    rendered_records = "\n".join(record.getMessage() for record in caplog.records)
+    assert "failed event" in rendered_records
+    assert "RuntimeError: boom" in rendered_records
+    assert "\u256d" not in rendered_records
+
+
 def test_configure_logging_writes_stdlib_and_structlog_events() -> None:
     cfg = Config(logging=LoggingConfig(enabled=True))
 

--- a/tests/core_orchestrator_workflows_test.py
+++ b/tests/core_orchestrator_workflows_test.py
@@ -962,41 +962,6 @@ def test_delete_repo_cleans_up_local_state_when_s3_delete_fails(
     assert excludes_path.exists() is False
 
 
-def test_orchestrator_creates_default_s3_client_when_online(monkeypatch: pytest.MonkeyPatch) -> None:
-    created_configs: list[object] = []
-
-    class _FakeS3Client:
-        def __init__(self, config: object) -> None:
-            created_configs.append(config)
-
-    monkeypatch.setattr("borgboi.clients.s3_client.S3Client", _FakeS3Client)
-
-    orchestrator = Orchestrator(
-        config=Config(offline=False),
-        borg_client=cast(Any, Mock()),
-        storage=cast(Any, Mock()),
-    )
-
-    assert created_configs == [orchestrator.config.aws]
-    assert orchestrator.s3 is not None
-
-
-def test_orchestrator_skips_default_s3_client_when_offline(monkeypatch: pytest.MonkeyPatch) -> None:
-    class _FakeS3Client:
-        def __init__(self, config: object) -> None:
-            raise AssertionError("S3 client should not be created in offline mode")
-
-    monkeypatch.setattr("borgboi.clients.s3_client.S3Client", _FakeS3Client)
-
-    orchestrator = Orchestrator(
-        config=Config(offline=True),
-        borg_client=cast(Any, Mock()),
-        storage=cast(Any, Mock()),
-    )
-
-    assert orchestrator.s3 is None
-
-
 def test_sync_to_s3_renders_with_expected_rich_style() -> None:
     repo = _build_repo()
     storage = Mock()

--- a/tests/test_sqlite_migration.py
+++ b/tests/test_sqlite_migration.py
@@ -2,14 +2,18 @@
 
 import json
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
 
 from borgboi.config import Config
-from borgboi.core.orchestrator import Orchestrator
-from borgboi.core.output import CollectingOutputHandler
-from borgboi.storage.db import RepositoryRow, S3StatsCacheRow, get_db_path, get_session_factory, init_db
+from borgboi.storage.db import (
+    RepositoryRow,
+    S3StatsCacheRow,
+    get_db_path,
+    get_session_factory,
+    init_db,
+    init_local_database,
+)
 from borgboi.storage.sqlite_migration import (
     auto_migrate_if_needed,
     migrate_json_repositories,
@@ -186,8 +190,9 @@ class TestAutoMigration:
             engine.dispose()
 
 
-def test_online_orchestrator_bootstraps_local_sqlite(
+def test_init_local_database_migrates_legacy_layout(
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.delenv("BORGBOI_OFFLINE", raising=False)
 
@@ -212,21 +217,12 @@ def test_online_orchestrator_bootstraps_local_sqlite(
     finally:
         legacy_engine.dispose()
 
-    class DummyDynamoDBStorage:
-        def __init__(self, config: Config | None = None, table_name: str | None = None) -> None:
-            self.config = config
-            self.table_name = table_name
-
-    monkeypatch.setattr("borgboi.storage.dynamodb.DynamoDBStorage", DummyDynamoDBStorage)
-
-    output_handler = CollectingOutputHandler()
-    _ = Orchestrator(config=Config(offline=False), borg_client=cast(Any, object()), output_handler=output_handler)
+    init_local_database(Config(offline=False))
+    captured = capsys.readouterr()
 
     assert migrated_db_path.exists()
     assert not legacy_db_path.exists()
-    assert any(
-        message.startswith("Migrating local metadata database to") for _, message, _ in output_handler.log_messages
-    )
+    assert "Migrating local metadata database" in captured.out
 
     from borgboi.storage.sqlite import SQLiteStorage
 

--- a/tests/test_sqlite_migration.py
+++ b/tests/test_sqlite_migration.py
@@ -1,6 +1,7 @@
 """Tests for SQLite auto-migration from legacy formats."""
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -193,6 +194,7 @@ class TestAutoMigration:
 def test_init_local_database_migrates_legacy_layout(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.delenv("BORGBOI_OFFLINE", raising=False)
 
@@ -217,12 +219,13 @@ def test_init_local_database_migrates_legacy_layout(
     finally:
         legacy_engine.dispose()
 
-    init_local_database(Config(offline=False))
+    with caplog.at_level(logging.INFO, logger="borgboi.storage.db"):
+        init_local_database(Config(offline=False))
     captured = capsys.readouterr()
 
     assert migrated_db_path.exists()
     assert not legacy_db_path.exists()
-    assert "Migrating local metadata database" in captured.out
+    assert "Migrating local metadata database" in captured.out or "Migrating local metadata database" in caplog.text
 
     from borgboi.storage.sqlite import SQLiteStorage
 


### PR DESCRIPTION
## Summary
- Strip the SQLite/DynamoDB/S3 client bootstrap out of `Orchestrator`; it now takes `storage` as a required injected dependency and never reaches into config-driven side effects on construction.
- Move the local-SQLite migration bootstrap into a new `init_local_database()` helper in `storage/db.py`. The CLI and TUI composition roots call it before constructing a cloud-mode `Orchestrator`.
- Remove the implicit `get_db_path()` fallback from `SQLiteDailyBackupProgressHistory`; all callers now pass the path explicitly.

## Phase B follow-up to #256
This is the second phase of the dual-orchestrator / storage-seam deepening work outlined after PR1 (#256). PR1 deleted dead procedural code; this PR finishes the deepening by giving `Orchestrator` a single composition root that owns the choice of storage backend and the local-DB bootstrap.

## Test plan
- [x] ` just lint` clean
- [x] `just test` — 621 passed, 1 skipped
- [x] Verified manual paths: CLI offline mode constructs `SQLiteStorage`; CLI online mode runs `init_local_database` then constructs `DynamoDBStorage`+`S3Client`; TUI mirrors both paths via `BorgBoiApp.on_mount` + `orchestrator` property.
- [x] `test_init_local_database_migrates_legacy_layout` rewritten to exercise the new helper directly (via capsys, since structlog is unconfigured in tests).