### PR TITLE
fix: split S3 progress output lines

### DIFF
--- a/src/borgboi/clients/s3_client.py
+++ b/src/borgboi/clients/s3_client.py
@@ -5,6 +5,7 @@ replacing the procedural functions in s3.py. It supports dependency injection
 for testing and different S3 backends.
 """
 
+import io
 import json
 import subprocess as sp
 from abc import ABC, abstractmethod
@@ -172,25 +173,26 @@ class S3Client(S3ClientInterface):
             StorageError: If the command fails
         """
         proc = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE)  # noqa: S603
-        out_stream = proc.stdout
-
-        if not out_stream:
+        if not proc.stdout:
             raise StorageError(f"{error_msg}: stdout is None")
 
-        while out_stream.readable():
-            line = out_stream.readline()
-            if not line:
-                if proc.stdout:
-                    proc.stdout.close()
-                if proc.stderr:
-                    proc.stderr.close()
-                break
-            yield line.decode("utf-8").rstrip("\n")
+        # AWS CLI progress messages use \r to redraw the current terminal line.
+        # Universal newlines normalize \r, \n, and \r\n so each update renders separately.
+        text_stream = io.TextIOWrapper(proc.stdout, encoding="utf-8", errors="replace")
+        try:
+            for line in text_stream:
+                yield line.rstrip("\n")
+        finally:
+            text_stream.close()
 
         returncode = proc.wait()
-        if returncode != 0:
-            stderr = proc.stderr.read().decode("utf-8") if proc.stderr else ""
-            raise StorageError(f"{error_msg} (exit code {returncode}): {stderr}", operation="s3_sync")
+        try:
+            if returncode != 0:
+                stderr = proc.stderr.read().decode("utf-8") if proc.stderr else ""
+                raise StorageError(f"{error_msg} (exit code {returncode}): {stderr}", operation="s3_sync")
+        finally:
+            if proc.stderr:
+                proc.stderr.close()
 
     @override
     def sync_to_bucket(self, local_path: str | Path, repo_name: str) -> Generator[str]:

--- a/tests/s3_client_test.py
+++ b/tests/s3_client_test.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import io
 import json
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,24 +15,9 @@ from borgboi.core.errors import StorageError
 from borgboi.storage.models import S3RepoStats
 
 
-class _FakeStream:
+class _FakeStream(io.BytesIO):
     def __init__(self, lines: list[bytes] | None = None, read_data: bytes = b"") -> None:
-        self._lines = list(lines or [])
-        self._read_data = read_data
-
-    def readable(self) -> bool:
-        return True
-
-    def readline(self) -> bytes:
-        if self._lines:
-            return self._lines.pop(0)
-        return b""
-
-    def read(self) -> bytes:
-        return self._read_data
-
-    def close(self) -> None:
-        pass
+        super().__init__(b"".join(lines) if lines is not None else read_data)
 
 
 class _FakeProcess:
@@ -133,6 +120,41 @@ def test_run_streaming_command_yields_output_lines(
     lines = list(client._run_streaming_command(["aws", "s3", "sync"]))
 
     assert lines == ["first", "second"]
+
+
+@pytest.mark.parametrize(
+    ("script", "expected"),
+    [
+        pytest.param(
+            r"import sys; sys.stdout.buffer.write(b'alpha\nbeta\ngamma\n')",
+            ["alpha", "beta", "gamma"],
+            id="newline",
+        ),
+        pytest.param(
+            r"import sys; sys.stdout.buffer.write(b'tick1\rtick2\rtick3\r')",
+            ["tick1", "tick2", "tick3"],
+            id="carriage-return",
+        ),
+        pytest.param(
+            r"import sys; sys.stdout.buffer.write(b'line1\r\nline2\r\n')",
+            ["line1", "line2"],
+            id="crlf",
+        ),
+        pytest.param(
+            r"import sys; sys.stdout.buffer.write(b'progress\rinfo\nwarn\r\ndone\n')",
+            ["progress", "info", "warn", "done"],
+            id="mixed",
+        ),
+    ],
+)
+def test_run_streaming_command_splits_aws_progress_line_endings(
+    script: str,
+    expected: list[str],
+    client: s3_client_module.S3Client,
+) -> None:
+    lines = list(client._run_streaming_command([sys.executable, "-c", script]))
+
+    assert lines == expected
 
 
 def test_run_streaming_command_raises_when_stdout_missing(


### PR DESCRIPTION
## Summary
- split AWS CLI S3 progress output on carriage returns as well as newlines
- preserve per-line rendering through TextIOWrapper universal-newlines handling
- add regression coverage for newline, carriage-return, CRLF, and mixed line endings

## Tests
- uv run pytest tests/s3_client_test.py -vv --capture=tee-sys --diff-symbols
- uv run ruff check src/borgboi/clients/s3_client.py tests/s3_client_test.py